### PR TITLE
[Patch] Switch to Chiron Sans HK

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
     <meta name="theme-color" content="#000000" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/chiron-fonts/chiron-sans-hk-pro@1.010/build/webfont/css/vf.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/chiron-fonts/chiron-sans-hk-pro@1.010/build/webfont/css/vf-italic.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/oswald@4.5.1/latin.css"> 
 
     <meta
       name="description"

--- a/public/index.html
+++ b/public/index.html
@@ -9,12 +9,8 @@
     <link rel="alternative" hreflang="x-default" href="https://hkbus.app/zh" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0" />
     <meta name="theme-color" content="#000000" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preload" as="style" 
-      href="https://fonts.googleapis.com/css2?family=Oswald:wght@500&family=Noto+Sans+TC:wght@400;900&family=Chivo:wght@400;900&display=swap" />
-    <link rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Oswald:wght@500&family=Noto+Sans+TC:wght@400;900&family=Chivo:wght@400;900&display=swap"
-      media="print" onload="this.media='all'" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/chiron-fonts/chiron-sans-hk-pro@1.010/build/webfont/css/vf.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/chiron-fonts/chiron-sans-hk-pro@1.010/build/webfont/css/vf-italic.css"/>
 
     <meta
       name="description"

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,13 @@
     <link rel="alternative" hreflang="x-default" href="https://hkbus.app/zh" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0" />
     <meta name="theme-color" content="#000000" />
+
+    <link rel="preconnect" href="https://cdn.jsdelivr.net">
+
+    <link rel="preload" href="https://cdn.jsdelivr.net/gh/chiron-fonts/chiron-sans-hk-pro@1.010/build/webfont/css/vf.css" as="style">
+    <link rel="preload" href="https://cdn.jsdelivr.net/gh/chiron-fonts/chiron-sans-hk-pro@1.010/build/webfont/css/vf-italic.css" as="style">
+    <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fontsource/oswald@4.5.1/latin.css" as="style">
+
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/chiron-fonts/chiron-sans-hk-pro@1.010/build/webfont/css/vf.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/chiron-fonts/chiron-sans-hk-pro@1.010/build/webfont/css/vf-italic.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/oswald@4.5.1/latin.css"> 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,7 @@ const emotionCache = createCache({
 
 const getThemeTokens = (mode: PaletteMode) => ({
   typography: {
-    fontFamily: "Noto Sans TC, Chivo, sans-serif",
+    fontFamily: "Chiron Sans HK Pro WS, Chivo, sans-serif",
   },
   palette: {
     mode,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,7 @@ const emotionCache = createCache({
 
 const getThemeTokens = (mode: PaletteMode) => ({
   typography: {
-    fontFamily: "Chiron Sans HK Pro WS, sans-serif",
+    fontFamily: "'Chiron Sans HK Pro WS', sans-serif",
   },
   palette: {
     mode,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,7 @@ const emotionCache = createCache({
 
 const getThemeTokens = (mode: PaletteMode) => ({
   typography: {
-    fontFamily: "Chiron Sans HK Pro WS, Chivo, sans-serif",
+    fontFamily: "Chiron Sans HK Pro WS, sans-serif",
   },
   palette: {
     mode,


### PR DESCRIPTION
## Proposed feature in the PR
This PR aims to replace the use of Google Font, to something with a smaller file size, but without losing currently used font weights. Notably, the replacement should bring better results than the original font.

The choice of Chiron Sans HK, is because of the font itself is redrawn using the commonly used stroke orders, and is derived from Noto Sans CJK. Given the difference between the two is only about stroke orders, the design and "feelings" on the UI/UX will not alter a lot with such changes.

Further, the web font files of Chiron Sans HK, `Chiron Sans HK Pro WS`, are premade and smaller comparing to the Google Fonts version of Noto Sans CJK, the change will significantly brings down the total transfer file sizes for the application. Also, the font files are served using jsdelivr.net with a majority of Cloudflare POPs, it gives a major improvement in the loading time.

---

## Before
![Simulator Screen Shot - iPhone 13 - 2021-11-18 at 16 21 13](https://user-images.githubusercontent.com/1886237/142380915-18a3f386-f1cd-4917-83a3-bbe3c121642c.png)

## After
![Simulator Screen Shot - iPhone 13 - 2021-11-18 at 16 22 38](https://user-images.githubusercontent.com/1886237/142380970-6b634e37-76de-4533-ab34-1b97ec27229f.png)

## Difference (small portion of two screenshots)
![diff](https://user-images.githubusercontent.com/1886237/142383166-d5c8b893-e4b8-49a5-8e37-650444f01772.png)

