### PR TITLE
Update the translation and Add translation for "Source code" in setting screen

### DIFF
--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -81,7 +81,7 @@
       "新增至主畫面 / 安裝應用程式": "Add to Home screen / Install the app",
       "Route Search header": "Point-to-Point Bus route search",
       "Route Search description": "Point to point search",
-      "Route Search constraint": "Constraints：",
+      "Route Search constraint": "Constraints:",
       "Route Search caption 1": "Max. transfer once",
       "Route Search caption 2": "Max. walking distance is 500m",
       "Route Search caption 3": "Scheduled bus at the first station",
@@ -109,7 +109,9 @@
       "lightRail": "Light Rail",
       "mtr": "MTR",
       "route-search-no-result": "No Result",
-      "對頭線": "REV"
+      "對頭線": "REV",
+      "個性化設定":"Personalized Settings",
+      "常用報時排序":"Commonly used ETA Sorting"
     }
   },
   "zh": {
@@ -140,7 +142,8 @@
       "mtr": "港鐵",
       "KMB first": "九巴優先",
       "CTB-NWFB first": "新巴城巴優先",
-      "route-search-no-result": "沒有結果"
+      "route-search-no-result": "沒有結果",
+      "Source code":"源代碼"
     }
   }
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -250,7 +250,7 @@ const Settings = () => {
             </Avatar>
           </ListItemAvatar>
           <ListItemText
-            primary="Source code"
+            primary={t("Source code")}
             secondary={"GPL-3.0 License"}
             secondaryTypographyProps={{ component: "h3", variant: "body2" }}
           />


### PR DESCRIPTION
Changed punctuation for "Constraints:" (from 全形 to 半形 as it is English)  

Added following translation:
      "個性化設定":"Personalized Settings",
      "常用報時排序":"Commonly used ETA Sorting"

Added translation for "Source code":
"Source code":"源代碼"