### PR TITLE
Fix truncated route info on landing page and stop dialog

### DIFF
--- a/src/components/home/SuccinctEtas.tsx
+++ b/src/components/home/SuccinctEtas.tsx
@@ -74,7 +74,6 @@ const classes = {
 
 const EtaListItemText = styled(ListItemText)(({ theme }) => ({
   [`&.${classes.root}`]: {
-    width: "25%",
     textAlign: "right",
   },
   [`& .${classes.secondary}`]: {

--- a/src/components/home/SuccinctTimeReport.tsx
+++ b/src/components/home/SuccinctTimeReport.tsx
@@ -103,7 +103,6 @@ const SuccinctTimeReport = ({
       >
         <ListItemText
           primary={<RouteNo routeNo={routeNo} />}
-          className={classes.route}
         />
         <ListItemText
           primary={
@@ -178,16 +177,13 @@ const classes = {
 };
 
 const RootListItem = styled(ListItem)(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: '15% 1fr 18%',
   [`&.${classes.listItem}`]: {
     padding: "4px 16px",
     color: "rgba(0,0,0,0.87)",
   },
-  [`& .${classes.route}`]: {
-    width: "15%",
-  },
   [`& .${classes.routeDest}`]: {
-    width: "50%",
-    whiteSpace: "nowrap",
     overflow: "hidden",
   },
   [`& .${classes.fromToWrapper}`]: {


### PR DESCRIPTION

**1. Landing**
Before
<img width="375" alt="image" src="https://user-images.githubusercontent.com/9110909/175076662-34ca949c-6def-473e-b1ba-9d0b7cdfcf63.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/9110909/175076896-7b23684b-1752-4411-902d-7730a60ff22c.png">

After
<img width="375" alt="image" src="https://user-images.githubusercontent.com/9110909/175077412-b8aab0f3-8cd1-45a8-a5cc-5c4bcca96f03.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/9110909/175077433-a4b2be16-3d9e-4707-9739-fe267348bb63.png">



**2. Stop Dialog**
Before
<img width="375" alt="image" src="https://user-images.githubusercontent.com/9110909/175077232-6dafd676-c69d-4cdc-99d2-2ab2d76432cd.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/9110909/175077261-88cfd40a-9b5f-4970-96b3-4b4cb62a544e.png">

After
<img width="375" alt="image" src="https://user-images.githubusercontent.com/9110909/175076577-0c6a0c91-271b-49ae-b16f-6d891d391375.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/9110909/175076591-ade8b812-a696-40fc-b515-ffe7476b8e04.png">
