### PR TITLE
remove veritical space

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -136,11 +136,11 @@ const Root = styled(BottomNavigation)(({ theme }) => ({
       theme.palette.mode === "dark"
         ? theme.palette.background.default
         : theme.palette.primary.main,
-    position: "sticky",
     bottom: "0",
     height: "initial",
     [`& .MuiBottomNavigationAction-root`]: {
       width: "20%",
+      padding: "6px 0",
       minWidth: 0,
     },
     [`& .MuiBottomNavigationAction-label`]: {

--- a/src/components/route-board/RouteInputPad.tsx
+++ b/src/components/route-board/RouteInputPad.tsx
@@ -120,7 +120,6 @@ const InputPadBox = styled(Box)(({ theme }) => ({
     // TODO: increase to 258px or enable scroll
     height: "248px",
     justifyContent: "space-around",
-    paddingTop: "8px",
   },
   [`& .${classes.numPadContainer}`]: {
     width: "72%",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -77,7 +77,6 @@ export default Home;
 const paperSx: SxProps<Theme> = {
   background: (theme) =>
     theme.palette.mode === "dark" ? theme.palette.background.default : "white",
-  height: "calc(100vh - 125px)",
   textAlign: "center",
   display: "flex",
   flexDirection: "column",

--- a/src/pages/RouteSearch.tsx
+++ b/src/pages/RouteSearch.tsx
@@ -322,7 +322,6 @@ const Root = styled(Paper)(({ theme }) => ({
       theme.palette.mode === "dark"
         ? theme.palette.background.default
         : "white",
-    height: "calc(100vh - 125px)",
     overflowY: "hidden",
     textAlign: "left",
   },


### PR DESCRIPTION
1. Remove space between the top toolbar and the 'All/NearBy/Starred' tab
2. Fix bottom menu bar button top padding

Before
<img width="374" alt="image" src="https://user-images.githubusercontent.com/9110909/176357421-fc2343a9-f484-4a43-a56f-553d44d86d6b.png">


After
<img width="374" alt="image" src="https://user-images.githubusercontent.com/9110909/176357416-356b94ab-7af5-4a4b-a5f1-6a2f08ae0506.png">
