### PR TITLE
Fix small caps in last letter in MTR lines (e.g. TMʟ -> TML, TKʟ -> TKL, etc.)

### DIFF
--- a/src/components/route-board/RouteNo.tsx
+++ b/src/components/route-board/RouteNo.tsx
@@ -9,7 +9,7 @@ interface RouteNoProps {
 }
 
 const RouteNo = ({ routeNo, component, align }: RouteNoProps) => {
-  const [prefix, suffix] = routeNo.match(/[A-Z]+$/)
+  const [prefix, suffix] = routeNo.match(/[0-9][A-Z]+$/)
     ? [routeNo.slice(0, -1), routeNo.slice(-1)]
     : [routeNo, ""];
   return (


### PR DESCRIPTION
Fix small caps in last letter in MTR lines (e.g. TMʟ -> TML, TKʟ -> TKL, etc.)

![image](https://user-images.githubusercontent.com/15365495/195368985-6181976a-4267-4bad-ae19-5827dc479fe8.png)
