### PR TITLE
Hide collection on list if no routes in collection

### DIFF
--- a/src/components/home/SwipeableList.tsx
+++ b/src/components/home/SwipeableList.tsx
@@ -129,33 +129,32 @@ const SwipeableList = React.forwardRef<SwipeableListRef, SwipeableListProps>(
     );
 
     const SmartCollectionRouteList = useMemo(
-      () =>
-        selectedRoutes?.smartCollections.length > 0 ? (
+      () => 
+        selectedRoutes?.smartCollections?.filter(
+          ({ routes }) => !!routes.replaceAll("|", "")
+        ).length > 0 ? (
           <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-            {selectedRoutes.smartCollections.map(({ name, routes }, idx) => (
-              <Box key={`collection-${idx}`}>
-                <Typography variant="body1" sx={{ textAlign: "left" }}>
-                  <b>{name}</b>
-                </Typography>
-                <List disablePadding>
-                  {routes
-                    .split("|")
-                    .map(
-                      (selectedRoute, idx) =>
-                        Boolean(selectedRoute) && (
-                          <SuccinctTimeReport
-                            key={`route-shortcut-${idx}`}
-                            routeId={selectedRoute}
-                          />
-                        )
-                    )}
-                </List>
-                {routes.split("|").filter((v) => Boolean(v)).length === 0 && (
-                  <Typography sx={{ marginTop: 1 }}>
-                    {t("未有收藏路線")}
+            {selectedRoutes.smartCollections
+              .filter(({ routes }) => !!routes.replaceAll("|", ""))
+              .map(({ name, routes }, idx) => (
+                <Box key={`collection-${idx}`}>
+                  <Typography variant="body1" sx={{ textAlign: "left" }}>
+                    <b>{name}</b>
                   </Typography>
-                )}
-              </Box>
+                  <List disablePadding>
+                    {routes
+                      .split("|")
+                      .map(
+                        (selectedRoute, idx) =>
+                          Boolean(selectedRoute) && (
+                            <SuccinctTimeReport
+                              key={`route-shortcut-${idx}`}
+                              routeId={selectedRoute}
+                            />
+                          )
+                      )}
+                  </List>
+                </Box>
             ))}
           </Box>
         ) : (


### PR DESCRIPTION
Currently collections are shown under the collections tab even if no routes are in the collection, making it looks like an layout bug. This commit hide the entire collection if there are no routes in that collection.
![image](https://github.com/hkbus/hk-independent-bus-eta/assets/39459225/6b60f899-54f8-4e5f-8c6b-bc917031cf59)
