### PR TITLE
Feature/#94-add-destination-text

### DIFF
--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -28,7 +28,7 @@ const TimeReport = ({
     db: { routeList, stopList },
   } = useContext(AppContext);
   const etas = useEtas(`${routeId}/${seq}`);
-
+  console.log(etas);
   const stopId = Object.values(routeList[routeId].stops)[0][seq];
   const routeDest = routeList[routeId].dest;
 
@@ -148,6 +148,16 @@ const EtaLine = ({
 };
 
 const getRemark = (remark: string = "", language: string) => {
+  // replace only when single occurrence of single digit numerical string
+  // if the remark has more than one occurrence of numerical string
+  // or if the only numerical string occurrence are more than one digit, use original remark
+  const numbers = remark.match(/\d+/g);
+  if (numbers.length === 1 && numbers[0].length === 1) {
+    // only support single digit number
+    const PLATFORM = ["", "❶", "❷", "❸", "❹", "❺", "❻", "❼", "❽", "❾"];
+    remark = PLATFORM[numbers[0]];
+  }
+
   if (language === "zh") {
     return remark.replace(/▭▭/g, "雙卡").replace(/▭/g, "單卡");
   } else {

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -121,26 +121,22 @@ const EtaLine = ({
         component="span"
         sx={{ fontSize: "0.8em", textOverflow: "ellipsis" }}
       >
-        {t(co)}
-        &nbsp;
         {getRemark(remark[language], language)}
+        &nbsp;
+        {dest[language]}
+        &emsp;
         {branchRoute && dest[language] && (
-          <>
-            &emsp;
-            <Tooltip
-              title={dest[language]}
-              placement="top"
-              arrow={true}
-              enterTouchDelay={200}
-              leaveTouchDelay={200}
-            >
-              <CallSplitIcon
-                sx={{ transform: "rotate(90deg)", fontSize: "1em" }}
-              />
-            </Tooltip>
-            &emsp;
-            {dest[language]}
-          </>
+          <Tooltip
+            title={dest[language]}
+            placement="top"
+            arrow={true}
+            enterTouchDelay={200}
+            leaveTouchDelay={200}
+          >
+            <CallSplitIcon
+              sx={{ transform: "rotate(90deg)", fontSize: "1em" }}
+            />
+          </Tooltip>
         )}
       </Box>
     </Typography>

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -138,6 +138,8 @@ const EtaLine = ({
                 sx={{ transform: "rotate(90deg)", fontSize: "1em" }}
               />
             </Tooltip>
+            &emsp;
+            {dest[language]}
           </>
         )}
       </Box>

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -127,7 +127,7 @@ const EtaLine = ({
         &emsp;
         {branchRoute && dest[language] && (
           <Tooltip
-            title={dest[language]}
+            title={t('支線')}
             placement="top"
             arrow={true}
             enterTouchDelay={200}

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -28,7 +28,7 @@ const TimeReport = ({
     db: { routeList, stopList },
   } = useContext(AppContext);
   const etas = useEtas(`${routeId}/${seq}`);
-  console.log(etas);
+
   const stopId = Object.values(routeList[routeId].stops)[0][seq];
   const routeDest = routeList[routeId].dest;
 

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -145,7 +145,7 @@ const EtaLine = ({
 
 const getRemark = (remark: string = "", language: string) => {
   // retrieve single digit numerical string from remark as a circle text
-  const numbers = remark.match(/\d+/g);
+  const numbers = remark.match(/\d+/g) || [];
   // replace only when single occurrence of single digit numerical string
   // if the remark has more than one occurrence of numerical string
   // or if the only numerical string occurrence are more than one digit, use original remark

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -148,10 +148,11 @@ const EtaLine = ({
 };
 
 const getRemark = (remark: string = "", language: string) => {
+  // retrieve single digit numerical string from remark as a circle text
+  const numbers = remark.match(/\d+/g);
   // replace only when single occurrence of single digit numerical string
   // if the remark has more than one occurrence of numerical string
   // or if the only numerical string occurrence are more than one digit, use original remark
-  const numbers = remark.match(/\d+/g);
   if (numbers.length === 1 && numbers[0].length === 1) {
     // only support single digit number
     const PLATFORM = ["", "❶", "❷", "❸", "❹", "❺", "❻", "❼", "❽", "❾"];

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -116,14 +116,14 @@ const EtaLine = ({
           {exactTimeJsx}&emsp;{waitTimeJsx}
         </>
       )}
-      &emsp;-&nbsp;
+      &emsp;
       <Box
         component="span"
         sx={{ fontSize: "0.8em", textOverflow: "ellipsis" }}
       >
-        {getRemark(remark[language], language)}
-        &emsp;
         {t(co)}
+        &nbsp;
+        {getRemark(remark[language], language)}
         {branchRoute && dest[language] && (
           <>
             &emsp;

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -121,7 +121,7 @@ const EtaLine = ({
         component="span"
         sx={{ fontSize: "0.8em", textOverflow: "ellipsis" }}
       >
-        {getRemark(remark[language] ? remark[language] : "", language)}
+        {getRemark(remark[language], language)}
         &emsp;
         {t(co)}
         {branchRoute && dest[language] && (
@@ -147,7 +147,7 @@ const EtaLine = ({
   );
 };
 
-const getRemark = (remark: string, language: string) => {
+const getRemark = (remark: string = "", language: string) => {
   if (language === "zh") {
     return remark.replace(/▭▭/g, "雙卡").replace(/▭/g, "單卡");
   } else {

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -147,7 +147,8 @@
       "請按下圖指示增加": "Follow below steps to bookmark stops",
       "通告": "Notice",
       "注釋預定班次": "Annotate Scheduled Bus",
-      "搜尋記錄": "Search history"
+      "搜尋記錄": "Search history",
+      "支線": "Spur Line"
     }
   },
   "zh": {


### PR DESCRIPTION
<img src="https://github.com/hkbus/hk-independent-bus-eta/assets/104617343/2e5e7338-0094-4f3d-9a8b-2e947d53863d" width="300">

<img src="https://github.com/hkbus/hk-independent-bus-eta/assets/104617343/0c580ca3-904d-4330-a1c1-f0408692e2d2" width="300">

Respond to this [feature request](https://github.com/hkbus/hk-independent-bus-eta/issues/94).

- remove hyphen
- remove "港鐵"
- `CallSplitIcon` hover text changed to ["支線" / "Spur Line"](https://www.mtr.com.hk/ch/customer/main/eal-cross-boundary-service-resumption.html)
- replace single digit platform number with filled circle text
(personally, I feel this style is more visible to me but it mismatches with the hollow style in `src/components/home/SuccinctTimeReport.tsx` line 108 and need confirmation)
