### PR TITLE
Fix: Remove detectRetina to make map text readable on Mobile

### DIFF
--- a/src/components/route-eta/RouteMap.tsx
+++ b/src/components/route-eta/RouteMap.tsx
@@ -194,7 +194,6 @@ const RouteMap = ({
       >
         <TileLayer
           crossOrigin="anonymous"
-          detectRetina
           maxZoom={Leaflet.Browser.retina ? 20 : 19}
           maxNativeZoom={18}
           keepBuffer={10}


### PR DESCRIPTION
## Description

Fixes #79 

Remove `detectRetina` to make map text readable on Mobile. iPhone screenshots obtained using `browserstack`.

## Screenshots

|with `detectRetina`|no `detectRetina`|
|-----|-----|
|![Screenshot_20231122-185005](https://github.com/hkbus/hk-independent-bus-eta/assets/3271800/cd5c05f3-60b6-48b8-b55a-c29176598afe)|![Screenshot_20231122-185108](https://github.com/hkbus/hk-independent-bus-eta/assets/3271800/30ef9f76-0e19-4c87-bcc5-a09fe7a89a2d)|
|![Screenshot 2023-12-11 185458](https://github.com/hkbus/hk-independent-bus-eta/assets/3271800/1fe5d9f5-bfed-4e38-a56d-b86b3a2fdf13)|![Screenshot 2023-12-11 185601](https://github.com/hkbus/hk-independent-bus-eta/assets/3271800/1dafe642-ffc6-4375-8fd6-53cfd05be5f7)|


