### PR TITLE
Feat: [UI] Add custom stop icon on Map

### DIFF
--- a/src/components/map/MTR.svg
+++ b/src/components/map/MTR.svg
@@ -1,0 +1,3 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="20" cy="20" r="13" fill="white" stroke="black" stroke-width="4"/>
+</svg>

--- a/src/components/map/bus.svg
+++ b/src/components/map/bus.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="20" cy="9" r="7" fill="#FF4A4A"/>
+<rect x="15" y="6" width="10" height="6" fill="#D9D9D9"/>
+<line x1="20" y1="15" x2="20" y2="40" stroke="#FF4A4A" stroke-width="2"/>
+</svg>

--- a/src/components/map/minibus.svg
+++ b/src/components/map/minibus.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="15" y="3" width="10" height="12" rx="2" fill="#2DB875"/>
+<line x1="20" y1="15" x2="20" y2="40" stroke="#2DB875" stroke-width="2"/>
+</svg>

--- a/src/components/route-eta/RouteMap.tsx
+++ b/src/components/route-eta/RouteMap.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { MapContainer, Marker, TileLayer, GeoJSON } from "react-leaflet";
 import Leaflet from "leaflet";
-import markerIcon2X from "leaflet/dist/images/marker-icon-2x.png";
+import busStopIcon from "../map/bus.svg";
 import { Box, SxProps, Theme } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import AppContext from "../../AppContext";
@@ -233,8 +233,8 @@ const geoJsonStyle = function (feature: GeoJSON.Feature) {
 
 const BusStopMarker = ({ active, passed }) => {
   return Leaflet.divIcon({
-    iconSize: [25, 41],
-    iconAnchor: [12.5, 41],
+    iconSize: [40, 40],
+    iconAnchor: [20, 40],
     className: `${classes.marker} ${active ? classes.active : ""} ${
       passed ? classes.passed : ""
     }`,
@@ -260,16 +260,15 @@ const rootSx: SxProps<Theme> = {
     height: "35vh",
   },
   [`& .${classes.marker}`]: {
-    width: "25px",
-    height: "41px",
+    width: "40px",
+    height: "40px",
     zIndex: 618,
     outline: "none",
-    filter: "hue-rotate(130deg)",
-    backgroundImage: `url(${markerIcon2X})`,
+    backgroundImage: `url(${busStopIcon})`,
     backgroundSize: "cover",
   },
   [`& .${classes.active}`]: {
-    animation: "blinker 2s linear infinite",
+    animation: "blinker 2s cubic-bezier(0,1.5,1,1.5) infinite",
   },
   [`& .${classes.passed}`]: {
     filter: "grayscale(100%)",

--- a/src/components/route-search/SearchMap.tsx
+++ b/src/components/route-search/SearchMap.tsx
@@ -296,13 +296,10 @@ const rootSx: SxProps<Theme> = {
     height: "35vh",
   },
   [`& .${classes.marker}`]: {
-    marginLeft: "-12px",
-    marginTop: "-41px",
-    width: "25px",
-    height: "41px",
+    width: "40px",
+    height: "40px",
     zIndex: 618,
     outline: "none",
-    filter: "hue-rotate(130deg)",
     "&.lv-1": {
       filter: "hue-rotate(210deg) brightness(1.5)",
     },
@@ -314,7 +311,7 @@ const rootSx: SxProps<Theme> = {
     },
   },
   [`& .${classes.active}`]: {
-    animation: "blinker 2s linear infinite",
+    animation: "blinker 2s cubic-bezier(0,1.5,1,1.5) infinite",
   },
   [`& .${classes.passed}`]: {
     filter: "grayscale(100%)",

--- a/src/index.css
+++ b/src/index.css
@@ -57,7 +57,14 @@ a.tg {
 }
 
 @keyframes blinker {
+  0% {
+    opacity: 0.5;
+  }
   50% {
-    opacity: 0.3;
+    opacity: 1;
+    margin-top: -55px;
+  }
+  100% {
+    opacity: 0.5;
   }
 }


### PR DESCRIPTION
# Description

IMO the default map marker is not suitable for displaying route stops, because

- the icon is too fat, and obscures a large area of the map and overlaps with other stops
- the design does not fit with the rest of the application

Therefore, I designed and drawn these simple icons using [Figma](https://www.figma.com) in hopes of incorporating them into the app. Colors are chosen randomly according to taste, and should not be covered by trademark. (IANAL)


|bus|minibus|MTR|
|---|----|---|
|![bus@4x](https://github.com/hkbus/hk-independent-bus-eta/assets/3271800/ffc9f39f-aa93-438d-be53-b1e647bc965e)|![minibus@4x](https://github.com/hkbus/hk-independent-bus-eta/assets/3271800/7debea11-79bf-420b-a1dc-f130fa8df8bf)|![MTR@4x](https://github.com/hkbus/hk-independent-bus-eta/assets/3271800/90558fd4-86ac-477c-b9d9-2adfbfe849a1)|

I have also made some POC code changes to swap the default icon with the bus icon, and changed the current stop animation `blinker` slightly to hopefully increase visibility.

|before|after|
|----|----|
|![Screenshot 2024-01-05 at 05-11-33 5C 往 尖沙咀碼頭 - 巴士到站預報 App （免費無廣告）](https://github.com/hkbus/hk-independent-bus-eta/assets/3271800/3a1b6a7a-0066-4305-aa6e-59f690766528)|![Screenshot 2024-01-05 at 05-07-29 5C 往 尖沙咀碼頭 - 巴士到站預報 App （免費無廣告）](https://github.com/hkbus/hk-independent-bus-eta/assets/3271800/969a6cc7-e71f-4c88-8b1c-c44133a3c775)|

More work would be required if different icons would be used for different transport modes.
