### PR TITLE
Added button to launch into watch app directly

### DIFF
--- a/src/components/route-eta/StopAccordion.tsx
+++ b/src/components/route-eta/StopAccordion.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "react-i18next";
 import { toProperCase } from "../../utils";
 import TimeReport from "./TimeReport";
 import ShareIcon from "@mui/icons-material/Share";
+import WatchIcon from "@mui/icons-material/Watch";
 import { SharingModalProps } from "./SharingModal";
 import ReactNativeContext from "../../ReactNativeContext";
 
@@ -78,6 +79,14 @@ const StopAccordion = React.forwardRef<HTMLDivElement, StopAccordionProps>(
         });
       },
       [onShareClick, routeId, idx, stopId]
+    );
+
+    const handleWatchClick = useCallback(
+      (e) => {
+        const url = `https://loohpjames.com/hkbuseta/route/${routeId.toLowerCase()}/${stopId}%2C${idx}`;
+        window.open(url, "_blank");
+      },
+      [routeId, idx, stopId]
     );
 
     const handleChangeInner = useCallback(
@@ -154,6 +163,14 @@ const StopAccordion = React.forwardRef<HTMLDivElement, StopAccordionProps>(
               </IconButton>
             </Box>
             <Box>
+              <IconButton
+                aria-label="open-on-watch"
+                onClick={handleWatchClick}
+                style={{ backgroundColor: "transparent" }}
+                size="large"
+              >
+                <WatchIcon />
+              </IconButton>
               <IconButton
                 aria-label="share"
                 onClick={handleShareClick}

--- a/src/components/route-eta/StopAccordion.tsx
+++ b/src/components/route-eta/StopAccordion.tsx
@@ -55,6 +55,7 @@ const StopAccordion = React.forwardRef<HTMLDivElement, StopAccordionProps>(
     } = useContext(AppContext);
     const { alarmStopId, toggleStopAlarm } = useContext(ReactNativeContext);
     const { isStopAlarm } = useContext(ReactNativeContext);
+    const { os } = useContext(ReactNativeContext);
     const { t, i18n } = useTranslation();
     const { fares, faresHoliday } = routeList[routeId];
     const stop = stopList[stopId];
@@ -83,10 +84,12 @@ const StopAccordion = React.forwardRef<HTMLDivElement, StopAccordionProps>(
 
     const handleWatchClick = useCallback(
       (e) => {
-        const url = `https://loohpjames.com/hkbuseta/route/${routeId.toLowerCase()}/${stopId}%2C${idx}`;
+        const isApple = os === "ios" || /iPad|iPhone|iPod|Mac/.test(navigator.userAgent);
+        const subdomain = isApple ? "watch" : "wear";
+        const url = `https://${subdomain}.hkbus.app/route/${routeId.toLowerCase()}/${stopId}%2C${idx}`;
         window.open(url, "_blank");
       },
-      [routeId, idx, stopId]
+      [routeId, idx, stopId, os]
     );
 
     const handleChangeInner = useCallback(

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -51,7 +51,6 @@ import Donations from "../Donations";
 import PersonalizeDialog from "../components/settings/PersonalizeDialog";
 import { useNavigate } from "react-router-dom";
 import ReactNativeContext from "../ReactNativeContext";
-import { isSafari } from "react-world-compass";
 
 const Settings = () => {
   const {
@@ -67,6 +66,7 @@ const Settings = () => {
     analytics,
   } = useContext(AppContext);
   const { debug, toggleDebug } = useContext(ReactNativeContext);
+  const { os } = useContext(ReactNativeContext);
   const [updating, setUpdating] = useState(false);
   const [showGeoPermissionDenied, setShowGeoPermissionDenied] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
@@ -78,6 +78,7 @@ const Settings = () => {
     () => Math.floor(Math.random() * Donations.length),
     []
   );
+  const isApple = os === "ios" || /iPad|iPhone|iPod|Mac/.test(navigator.userAgent);
 
   const navigate = useNavigate();
 
@@ -289,9 +290,9 @@ const Settings = () => {
         <ListItemButton
           component={"a"}
           href={
-            isSafari
-              ? `https://hkbus.app/watch.html`
-              : `https://hkbus.app/wear.html`
+            isApple
+              ? `https://watch.hkbus.app/`
+              : `https://wear.hkbus.app/`
           }
           target="_blank"
           onClick={() => {


### PR DESCRIPTION
This skips the whole link-sharing workaround that is needed to send routes and stops to the watch, achieving Next-Level™ integration.
The button launches into the respective stop directly if the watch app is available, or the play-store/app-store if not depending on the device. Currently does not work for WatchOS as I'm still working on the iphone companion app, but this would work once that is completed. Works perfectly on Android/WearOS devices (once the app update is approved).