### PR TITLE
Fix Home Background to Full Height

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -70,4 +70,5 @@ const paperSx: SxProps<Theme> = {
   flexDirection: "column",
   overflow: "auto",
   width: "100%",
+  height: "100%",
 };


### PR DESCRIPTION
This simple change makes the background not feel like it is cut off.

From this:
<img width="434" alt="Screenshot 2024-01-22 at 20 36 33" src="https://github.com/hkbus/hk-independent-bus-eta/assets/22975196/8f5e8c9c-9d68-4554-8621-afe03c2e0e74">

To this:
<img width="434" alt="Screenshot 2024-01-22 at 20 35 26" src="https://github.com/hkbus/hk-independent-bus-eta/assets/22975196/8b50e962-32dc-4b95-a55b-2e9dbeeb68fc">
