### PR TITLE
More Informative Visualization when there are No Schedule

### DIFF
--- a/src/components/home/SuccinctEtas.tsx
+++ b/src/components/home/SuccinctEtas.tsx
@@ -20,7 +20,6 @@ const SuccinctEtas = ({ routeId, value = undefined }: SuccinctEtasProps) => {
 
   const getEtaString = (eta: Eta | null, highlight: boolean = false) => {
     if (!eta || !eta.eta) {
-      if (eta && eta.remark[i18n.language]) return eta.remark[i18n.language];
       return "";
     } else {
       const waitTime = Math.round(
@@ -93,12 +92,19 @@ const SuccinctEtas = ({ routeId, value = undefined }: SuccinctEtasProps) => {
     }
   };
 
+  let primary = etas ? getEtaString(etas[0], true) : "";
+  if (primary === "" && etas) {
+    primary = null;
+  }
+
   return (
     <ListItemText
       primary={
+        primary != null ? 
         <Typography component="h5" color="textPrimary" sx={primarySx}>
-          {etas ? getEtaString(etas[0], true) : ""}
-        </Typography>
+          {primary}
+        </Typography> :
+        <ScheduleIcon />
       }
       secondary={
         <Typography variant="h6" color="textSecondary" sx={secondarySx}>

--- a/src/components/home/SuccinctEtas.tsx
+++ b/src/components/home/SuccinctEtas.tsx
@@ -20,6 +20,7 @@ const SuccinctEtas = ({ routeId, value = undefined }: SuccinctEtasProps) => {
 
   const getEtaString = (eta: Eta | null, highlight: boolean = false) => {
     if (!eta || !eta.eta) {
+      if (eta && eta.remark[i18n.language]) return eta.remark[i18n.language];
       return "";
     } else {
       const waitTime = Math.round(

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -46,6 +46,15 @@ const TimeReport = ({
     );
   }
 
+  let noScheduleRemark;
+  if (etas.length > 0 && etas.every((e) => !e.eta) && etas[0].remark[language]) {
+    noScheduleRemark = etas[0].remark[language];
+  } else if (etas.length === 0 || etas.every((e) => !e.eta)) {
+    noScheduleRemark = t("未有班次資料");
+  } else {
+    noScheduleRemark = null;
+  }
+
   return (
     <Box sx={containerSx}>
       {showStopName && (
@@ -53,8 +62,8 @@ const TimeReport = ({
           {stopList[stopId].name[language]}
         </Typography>
       )}
-      {etas.length === 0 && t("未有班次資料")}
-      {etas.length > 0 &&
+      {noScheduleRemark && noScheduleRemark}
+      {etas.length > 0 && etas.every((e) => e.eta) &&
         etas.map((eta, idx) => (
           <EtaLine
             key={`route-${idx}`}

--- a/src/pages/RouteSearch.tsx
+++ b/src/pages/RouteSearch.tsx
@@ -72,7 +72,7 @@ const RouteSearch = () => {
               co: Object.keys(routeList[routeId].stops),
               // @ts-ignore
               language: i18n.language,
-            });
+            }).then((p) => p.filter((e) => e.eta));
       })
     )
       .then((etas) =>


### PR DESCRIPTION
In conjunction with https://github.com/hkbus/hk-bus-eta/pull/3, this PR brings a more precious reasoning such as "Last Bus Departed" instead of the generic no information message where possible.
Additionally, a clock icon is added to Succinct when there are no services for a particular route to distinguish between "Cannot connect to server" which would otherwise also be shown as blank.