### PR TITLE
Add Launch Route On Watch Button

### DIFF
--- a/src/components/route-eta/ReverseButton.tsx
+++ b/src/components/route-eta/ReverseButton.tsx
@@ -132,9 +132,6 @@ const buttonDividerSx: SxProps<Theme> = {
 const buttonSx: SxProps<Theme> = {
   color: (theme) =>
     theme.palette.getContrastText(theme.palette.background.default),
-  position: "absolute",
-  top: "0",
-  left: "2%",
   flexDirection: "column",
   justifyContent: "center",
   "& > .MuiButton-label": {

--- a/src/components/route-eta/RouteHeader.tsx
+++ b/src/components/route-eta/RouteHeader.tsx
@@ -7,6 +7,7 @@ import AppContext from "../../AppContext";
 import ReverseButton from "./ReverseButton";
 import TimetableButton from "./TimeTableButton";
 import RouteStarButton from "./RouteStarButton";
+import RouteWatchButton from "./RouteWatchButton";
 
 const RouteHeader = ({ routeId }: { routeId: string }) => {
   const { t, i18n } = useTranslation();
@@ -23,6 +24,7 @@ const RouteHeader = ({ routeId }: { routeId: string }) => {
         {nlbId ? t("由") + " " + toProperCase(orig[i18n.language]) : ""}
       </Typography>
       <ReverseButton routeId={routeId} />
+      <RouteWatchButton routeId={routeId} />
       <Box sx={rightBtnGroupSx}>
         <RouteStarButton routeId={routeId} />
         <TimetableButton routeId={routeId} />

--- a/src/components/route-eta/RouteHeader.tsx
+++ b/src/components/route-eta/RouteHeader.tsx
@@ -23,8 +23,10 @@ const RouteHeader = ({ routeId }: { routeId: string }) => {
         {t("往")} {toProperCase(dest[i18n.language])}{" "}
         {nlbId ? t("由") + " " + toProperCase(orig[i18n.language]) : ""}
       </Typography>
-      <ReverseButton routeId={routeId} />
-      <RouteWatchButton routeId={routeId} />
+      <Box sx={leftBtnGroupSx}>
+        <ReverseButton routeId={routeId} />
+        <RouteWatchButton routeId={routeId} />
+      </Box>
       <Box sx={rightBtnGroupSx}>
         <RouteStarButton routeId={routeId} />
         <TimetableButton routeId={routeId} />
@@ -41,8 +43,18 @@ const PaperSx: SxProps<Theme> = {
   position: "relative",
 };
 
+const leftBtnGroupSx: SxProps<Theme> = {
+  position: "absolute",
+  top: "0",
+  height: "100%",
+  left: "1px",
+  display: "flex",
+};
+
 const rightBtnGroupSx: SxProps<Theme> = {
   position: "absolute",
   top: "0",
-  right: "2%",
+  height: "100%",
+  right: "1px",
+  display: "flex",
 };

--- a/src/components/route-eta/RouteWatchButton.tsx
+++ b/src/components/route-eta/RouteWatchButton.tsx
@@ -1,0 +1,43 @@
+import React, { useContext } from "react";
+import { IconButton, SxProps, Theme } from "@mui/material";
+import WatchIcon from "@mui/icons-material/Watch";
+import ReactNativeContext from "../../ReactNativeContext";
+
+const RouteWatchButton = ({ routeId }) => {
+  const { os } = useContext(ReactNativeContext);
+
+  return (
+    <IconButton
+      sx={buttonSx}
+      size="small"
+      onClick={() => {
+        const isApple =
+          os === "ios" || /iPad|iPhone|iPod|Mac/.test(navigator.userAgent);
+        const subdomain = isApple ? "watch" : "wear";
+        const url = `https://${subdomain}.hkbus.app/route/${routeId.toLowerCase()}`;
+        window.open(url, "_blank");
+      }}
+    >
+      <WatchIcon />
+    </IconButton>
+  );
+};
+
+export default RouteWatchButton;
+
+const buttonSx: SxProps<Theme> = {
+  color: (theme) =>
+    theme.palette.getContrastText(theme.palette.background.default),
+  position: "absolute",
+  top: "10px",
+  left: "17%",
+  flexDirection: "column",
+  justifyContent: "center",
+  "& > .MuiButton-label": {
+    flexDirection: "column",
+    justifyContent: "center",
+  },
+  "& > .MuiButton-startIcon": {
+    margin: 0,
+  },
+};

--- a/src/components/route-eta/RouteWatchButton.tsx
+++ b/src/components/route-eta/RouteWatchButton.tsx
@@ -28,9 +28,6 @@ export default RouteWatchButton;
 const buttonSx: SxProps<Theme> = {
   color: (theme) =>
     theme.palette.getContrastText(theme.palette.background.default),
-  position: "absolute",
-  top: "10px",
-  left: "17%",
   flexDirection: "column",
   justifyContent: "center",
   "& > .MuiButton-label": {

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -155,6 +155,7 @@
       "確定": "Confirm",
       "現在 / 預設位置": "Current / Default Location",
       "智能手錶應用程式": "Smart Watch App",
+      "支援 WearOS 及 WatchOS 平台": "Supports WearOS & WatchOS",
       "到站了": "Arrived!"
     }
   },

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -303,7 +303,10 @@ const Settings = () => {
               <WatchIcon />
             </Avatar>
           </ListItemAvatar>
-          <ListItemText primary={t("智能手錶應用程式")} />
+          <ListItemText 
+            primary={t("智能手錶應用程式")}
+            secondary={t("支援 WearOS 及 WatchOS 平台")}
+          />
         </ListItemButton>
         {!iOSRNWebView() ? (
           <ListItemButton


### PR DESCRIPTION
The previously added button launches into the ETA of the Bus Stop on the watch directly, this new button launches only the route, in case there isn't one particular stop the user wishes to check ETA for but a group of nearby stops on the route.

Continuation of #141: Well how about just put it on the right, if there is space on the left for the star, there must be enough space on the right since the text is centered.

<img width="406" alt="Screenshot 2024-01-28 at 03 57 00" src="https://github.com/hkbus/hk-independent-bus-eta/assets/22975196/205d7143-42e9-4555-a6f0-fe1c22e4394f">
