### PR TITLE
Add "Info" button to the route detail page header

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dom-to-image": "^2.6.0",
     "dotenv": "^16.0.1",
     "gh-pages": "^4.0.0",
-    "hk-bus-eta": "^3.2.1",
+    "hk-bus-eta": "^3.3.0",
     "i18next": "^21.8.10",
     "immer": "^9.0.15",
     "leaflet": "^1.7.1",

--- a/src/components/route-board/RouteNo.tsx
+++ b/src/components/route-board/RouteNo.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { SxProps, Theme, Typography } from "@mui/material";
 
 interface RouteNoProps {
@@ -43,7 +42,6 @@ export default RouteNo;
 
 const rootSx: SxProps<Theme> = {
   lineHeight: "normal",
-  display: "inline",
   "& > span:nth-of-type(1)": {
     fontSize: "1.5rem",
     fontFamily: '"Oswald", sans-serif',

--- a/src/components/route-eta/InfoButton.tsx
+++ b/src/components/route-eta/InfoButton.tsx
@@ -1,43 +1,35 @@
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import { Button, SxProps, Theme } from "@mui/material";
-import { Schedule as ScheduleIcon } from "@mui/icons-material";
-import TimetableDrawer from "./TimetableDrawer";
+import { Public as PublicIcon } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 import AppContext from "../../AppContext";
 
-const TimeTableButton = ({ routeId }: { routeId: string }) => {
-  const [isOpen, setIsOpen] = useState(false);
+const InfoButton = ({ routeId }: { routeId: string }) => {
   const { t } = useTranslation();
   const {
     db: { routeList },
   } = useContext(AppContext);
-  const { freq, jt } = routeList[routeId];
+  const { url } = routeList[routeId];
 
   return (
-    freq && (
+    url && (
       <>
         <Button
           variant="text"
-          aria-label="open-timetable"
+          aria-label="open-information"
           sx={buttonSx}
           size="small"
-          startIcon={<ScheduleIcon />}
-          onClick={() => setIsOpen(true)}
+          startIcon={<PublicIcon />}
+          onClick={() => window.open(url, "_blank")}
         >
-          {t("時間表")}
+          {t("資訊")}
         </Button>
-        <TimetableDrawer
-          freq={freq}
-          jt={jt}
-          open={isOpen}
-          onClose={() => setIsOpen(false)}
-        />
       </>
     )
   );
 };
 
-export default TimeTableButton;
+export default InfoButton;
 
 const buttonSx: SxProps<Theme> = {
   color: (theme) =>

--- a/src/components/route-eta/ReverseButton.tsx
+++ b/src/components/route-eta/ReverseButton.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useMemo, useCallback } from "react";
-import { Button, Divider, SxProps, Theme } from "@mui/material";
+import { useContext, useMemo, useCallback } from "react";
+import { Button, SxProps, Theme } from "@mui/material";
 import { SyncAlt as SyncAltIcon } from "@mui/icons-material";
 import { RouteListEntry } from "hk-bus-eta";
 import { useNavigate } from "react-router-dom";
@@ -105,10 +105,9 @@ const ReverseButton = ({ routeId }: { routeId: string }) => {
   return (
     reverseRoute.length > 0 && (
       <>
-        <Divider orientation="vertical" sx={buttonDividerSx} />
         <Button
           variant="text"
-          aria-label="open-timetable"
+          aria-label="reverse"
           sx={buttonSx}
           size="small"
           startIcon={<SyncAltIcon />}
@@ -123,20 +122,12 @@ const ReverseButton = ({ routeId }: { routeId: string }) => {
 
 export default ReverseButton;
 
-const buttonDividerSx: SxProps<Theme> = {
-  position: "absolute",
-  top: "0",
-  left: "calc(64px + 2%)",
-};
-
 const buttonSx: SxProps<Theme> = {
   color: (theme) =>
     theme.palette.getContrastText(theme.palette.background.default),
-  position: "absolute",
-  top: "0",
-  left: "2%",
   flexDirection: "column",
   justifyContent: "center",
+  minWidth: "50px",
   "& > .MuiButton-label": {
     flexDirection: "column",
     justifyContent: "center",

--- a/src/components/route-eta/RouteHeader.tsx
+++ b/src/components/route-eta/RouteHeader.tsx
@@ -1,5 +1,5 @@
-import React, { useContext } from "react";
-import { Box, Paper, SxProps, Theme, Typography } from "@mui/material";
+import { useContext } from "react";
+import { Divider, Grid, SxProps, Theme, Typography } from "@mui/material";
 import RouteNo from "../route-board/RouteNo";
 import { toProperCase } from "../../utils";
 import { useTranslation } from "react-i18next";
@@ -7,6 +7,7 @@ import AppContext from "../../AppContext";
 import ReverseButton from "./ReverseButton";
 import TimetableButton from "./TimeTableButton";
 import RouteStarButton from "./RouteStarButton";
+import InfoButton from "./InfoButton";
 
 const RouteHeader = ({ routeId }: { routeId: string }) => {
   const { t, i18n } = useTranslation();
@@ -16,31 +17,31 @@ const RouteHeader = ({ routeId }: { routeId: string }) => {
   const { route, orig, dest, nlbId } = routeList[routeId];
 
   return (
-    <Paper id="route-eta-header" sx={PaperSx} elevation={0}>
-      <RouteNo routeNo={route} component="h1" align="center" />
-      <Typography component="h2" variant="caption" align="center">
-        {t("往")} {toProperCase(dest[i18n.language])}{" "}
-        {nlbId ? t("由") + " " + toProperCase(orig[i18n.language]) : ""}
-      </Typography>
-      <ReverseButton routeId={routeId} />
-      <Box sx={rightBtnGroupSx}>
+    <Grid container id="route-eta-header">
+      <Grid item xs="auto" sx={btnGroupSx}>
+        <ReverseButton routeId={routeId} />
+        <Divider orientation="vertical" />
+      </Grid>
+      <Grid item xs>
+        <RouteNo routeNo={route} component="h1" align="center" />
+        <Typography component="h2" variant="caption" align="center">
+          {t("往")} {toProperCase(dest[i18n.language])}{" "}
+          {nlbId ? t("由") + " " + toProperCase(orig[i18n.language]) : ""}
+        </Typography>
+      </Grid>
+      <Grid item xs="auto" sx={btnGroupSx}>
         <RouteStarButton routeId={routeId} />
+        <Divider orientation="vertical" />
+        <InfoButton routeId={routeId} />
         <TimetableButton routeId={routeId} />
-      </Box>
-    </Paper>
+      </Grid>
+    </Grid>
   );
 };
 
 export default RouteHeader;
 
-const PaperSx: SxProps<Theme> = {
-  textAlign: "center",
-  background: "transparent",
-  position: "relative",
-};
-
-const rightBtnGroupSx: SxProps<Theme> = {
-  position: "absolute",
-  top: "0",
-  right: "2%",
+const btnGroupSx: SxProps<Theme> = {
+  display: "flex",
+  flexDirection: "row",
 };

--- a/src/i18n/translation.json
+++ b/src/i18n/translation.json
@@ -108,6 +108,7 @@
       "所有日子": "All Days",
       "除星期三外": "Except Wednesday",
       "時間表": "SCHED.",
+      "資訊": "Info",
       "綜合": "All",
       "常用": "Starred",
       "附近": "Nearby",


### PR DESCRIPTION
Implements #150. Requires merging hkbus/hk-bus-crawling#18 and hkbus/hk-bus-eta#4 first.

This pull request adds a new "Info" button to the route detail page header. The button will show only when the agency website URL is included in the route object. Tapping this button will open the agency website in a new browser tab or window.

![image](https://github.com/hkbus/hk-independent-bus-eta/assets/5405949/cb151905-c46d-4eee-aa7d-be849c0412af)
