### PR TITLE
Fix long notice text fails to break in to newline

### DIFF
--- a/src/pages/Notice.tsx
+++ b/src/pages/Notice.tsx
@@ -73,6 +73,7 @@ const noticeContainerSx: SxProps<Theme> = {
   display: "flex",
   flexDirection: "column",
   gap: 2,
+  wordBreak: "break-word",
 };
 
 const linkSx: SxProps<Theme> = {


### PR DESCRIPTION
This is a PR to fix long continuous text under "Notice" tab being overflow.

Screenshot:
![SS 2024-02-12 at 9 27 46 AM](https://github.com/hkbus/hk-independent-bus-eta/assets/1617708/df419838-8f78-42b3-92dd-5aacf0e2fc2d)

resolves #152 #121 