### PR TITLE
Update utils.ts by enhancing CTB Route Colour

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -489,7 +489,7 @@ export const getLineColor = (
   } else if (companies.includes("kmb")) {
     color = "#FF4747";
   } else if (companies.includes("ctb")) {
-    color = "#FFE15E";
+    color = "#FF4747";
   }
   return color;
 };


### PR DESCRIPTION
Refer to issue [#158](https://github.com/hkbus/hk-independent-bus-eta/issues/158), enhancing CTB Route Colour, from yellow to red. Thus users can familiar with the CTB Route much easier. 

![01](https://github.com/hkbus/hk-independent-bus-eta/assets/13661271/50d1b82f-f7c7-4bbc-a0ee-01402f900068)
![02](https://github.com/hkbus/hk-independent-bus-eta/assets/13661271/80153d7f-d69d-4541-9143-c47dc0f024b3)
