### PR TITLE
Add black border to route path strokes

### DIFF
--- a/src/components/route-eta/RouteMap.tsx
+++ b/src/components/route-eta/RouteMap.tsx
@@ -217,11 +217,18 @@ const RouteMap = ({
         {
           // @ts-ignore
           routePath?.features?.length && (
-            <GeoJSON
-              key={routePath?.["timeStamp"]}
-              data={routePath}
-              style={geoJsonStyle(companies, route)}
-            />
+            <>
+              <GeoJSON
+                key={routePath?.["timeStamp"]}
+                data={routePath}
+                style={geoJsonStyle(companies, route, true)}
+              />
+              <GeoJSON
+                key={routePath?.["timeStamp"]}
+                data={routePath}
+                style={geoJsonStyle(companies, route, false)}
+              />
+            </>
           )
         }
         <SelfCircle />
@@ -234,11 +241,11 @@ const RouteMap = ({
 
 export default RouteMap;
 
-const geoJsonStyle = (companies, route) => {
+const geoJsonStyle = (companies, route, isBorder) => {
   return function (feature: GeoJSON.Feature) {
     return {
-      color: getLineColor(companies, route),
-      weight: 4,
+      color: isBorder ? '#000000' : getLineColor(companies, route),
+      weight: isBorder ? 6 : 4,
       className:
         companies.includes("ctb") && companies.includes("kmb")
           ? classes.jointlyLine

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -489,7 +489,7 @@ export const getLineColor = (
   } else if (companies.includes("kmb")) {
     color = "#FF4747";
   } else if (companies.includes("ctb")) {
-    color = "#0055B8";
+    color = "#FFE15E";
   }
   return color;
 };


### PR DESCRIPTION
## Further improvements on Issue #158 and PR #162

- add black border to avoid route path being same colour (invisible) from background map
- restore company colour #FFE15E (yellow) to CTB (now that the colour no longer invisible)

The hack: draw a black coloured stroke with slightly thicker stroke width (6px) first (in background) before drawing the original 4px-wide route-line 
https://stackoverflow.com/questions/8845426/how-to-make-an-svg-line-with-a-border-around-it

## Example images

Light mode:

![image](https://github.com/hkbus/hk-independent-bus-eta/assets/15365495/9e149233-c20d-4311-b383-7d4dff0f4ea7)
![image](https://github.com/hkbus/hk-independent-bus-eta/assets/15365495/8f82fcdd-150f-427b-8f74-6f8eec89cbf0)

Dark mode:

![image](https://github.com/hkbus/hk-independent-bus-eta/assets/15365495/244e1b3b-93e2-47da-9722-3bf7332ee367)
![image](https://github.com/hkbus/hk-independent-bus-eta/assets/15365495/2690d509-ccee-4fa0-b6c5-6171350e10a0)

