### PR TITLE
Fix Issue #157 User Preference "Saved Stops" were in reverse order as the user saved the stops

### DIFF
--- a/src/components/settings/StopOrderList.tsx
+++ b/src/components/settings/StopOrderList.tsx
@@ -19,8 +19,7 @@ const StopOrderList = ({ mode }: { mode: ManageMode }) => {
     updateSavedStops,
   } = useContext(AppContext);
   const [items, setItems] = useState(
-    // cannot use Array.reverse() as it is in-place reverse
-    savedStops.filter((id) => id.split("|")[1] in stopList).reverse()
+    savedStops.filter((id) => id.split("|")[1] in stopList)
   );
   const { t } = useTranslation();
 
@@ -32,7 +31,7 @@ const StopOrderList = ({ mode }: { mode: ManageMode }) => {
       const newItems = reorder(items, source.index, destination.index);
 
       setItems(newItems);
-      setSavedStops(Array.from(newItems).reverse());
+      setSavedStops(Array.from(newItems));
     },
     [items, setItems, setSavedStops]
   );


### PR DESCRIPTION
## Bugfix: show correct order (left to right) and as user preference. Existing users with existing saved stops will retain their original order.

- See Issue #157 for screenshot

#### Correct order in "Saved Stops" tab

![image](https://github.com/hkbus/hk-independent-bus-eta/assets/15365495/9e183e04-9fa3-43e8-a54e-281b9713d8e4)

#### Incorrect order in settings page (Before commit)

![image](https://github.com/hkbus/hk-independent-bus-eta/assets/15365495/2ea8be7a-8c56-4ca5-a8a6-063dd62361b5)

#### Correct order in settings page (After commit)

![image](https://github.com/hkbus/hk-independent-bus-eta/assets/15365495/3b4e9590-3632-446d-90fc-97d2a979c14f)


