### PR TITLE
Fix lack of black border for animated route line in KMB/CTB joint routes

### DIFF
--- a/src/components/route-eta/RouteMap.tsx
+++ b/src/components/route-eta/RouteMap.tsx
@@ -247,7 +247,7 @@ const geoJsonStyle = (companies, route, isBorder) => {
       color: isBorder ? "#000000" : getLineColor(companies, route),
       weight: isBorder ? 6 : 4,
       className:
-        companies.includes("ctb") && companies.includes("kmb")
+        companies.includes("ctb") && companies.includes("kmb") && !isBorder
           ? classes.jointlyLine
           : null,
     };


### PR DESCRIPTION
## Bug is as titled

#### Sample Screenshot (sorry too lazy to capture animated image)

#### Before Fix (without border)

![image](https://github.com/hkbus/hk-independent-bus-eta/assets/15365495/81796b0e-e73d-4eac-a3b0-06b7d96dad44)

#### After Fix (added black border)

![image](https://github.com/hkbus/hk-independent-bus-eta/assets/15365495/0f9a101e-37fd-4b27-aed8-f5de120c0c2e)

