### PR TITLE
Simplify Map Label Attribution

### DIFF
--- a/src/components/home/RangeMap.tsx
+++ b/src/components/home/RangeMap.tsx
@@ -79,7 +79,7 @@ const RangeMap = React.forwardRef<Leaflet.Map, RangeMapProps>(
           maxNativeZoom={18}
           keepBuffer={10}
           updateWhenIdle={false}
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a> © <a href="https://api.portal.hkmapservice.gov.hk/disclaimer">地圖版權屬香港特別行政區政府</a>'
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a> &copy; <a href="https://api.portal.hkmapservice.gov.hk/disclaimer">HKSARGov</a>'
           url={import.meta.env.VITE_MAP_LABEL_URL.replace(
             "{lang}",
             language === "zh" ? "tc" : "en"

--- a/src/components/route-eta/RouteMap.tsx
+++ b/src/components/route-eta/RouteMap.tsx
@@ -205,7 +205,7 @@ const RouteMap = ({
           maxNativeZoom={18}
           keepBuffer={10}
           updateWhenIdle={false}
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a> © <a href="https://api.portal.hkmapservice.gov.hk/disclaimer">地圖版權屬香港特別行政區政府</a>'
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a> &copy; <a href="https://api.portal.hkmapservice.gov.hk/disclaimer">HKSARGov</a>'
           url={import.meta.env.VITE_MAP_LABEL_URL.replace(
             "{lang}",
             language === "zh" ? "tc" : "en"

--- a/src/components/route-search/SearchMap.tsx
+++ b/src/components/route-search/SearchMap.tsx
@@ -278,7 +278,7 @@ const SearchMap = ({
           maxNativeZoom={18}
           keepBuffer={10}
           updateWhenIdle={false}
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a> © <a href="https://api.portal.hkmapservice.gov.hk/disclaimer">地圖版權屬香港特別行政區政府</a>'
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a> &copy; <a href="https://api.portal.hkmapservice.gov.hk/disclaimer">HKSARGov</a>'
           url={import.meta.env.VITE_MAP_LABEL_URL.replace(
             "{lang}",
             language === "zh" ? "tc" : "en"


### PR DESCRIPTION
I try to Simplify Map Label Attribution by replacing `HKSARGov` from `地圖版權屬香港特別行政區政府`; and also synchronize copyright symbol from Unicode `©` to HTML Symbol `"&copy;"`

![1](https://github.com/hkbus/hk-independent-bus-eta/assets/13661271/da5f2f57-be6c-4379-ba7d-669eef904bac)
![2](https://github.com/hkbus/hk-independent-bus-eta/assets/13661271/2aac2dc8-3690-4745-8f76-d5441bd348a1)
![3](https://github.com/hkbus/hk-independent-bus-eta/assets/13661271/d929f1bc-0d4e-4ef2-9e6a-0ad2ac528bb4)
![4](https://github.com/hkbus/hk-independent-bus-eta/assets/13661271/a4d4d263-956b-4317-afb9-f349dcd6591f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated map attribution text across various map components to "HKSARGov" for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->