### PR TITLE
fix "Click here to search all routes" missing space

### DIFF
--- a/src/components/route-board/SwipeableRoutesBoard.tsx
+++ b/src/components/route-board/SwipeableRoutesBoard.tsx
@@ -9,7 +9,7 @@ import SentimentVeryDissatisfiedIcon from "@mui/icons-material/SentimentVeryDiss
 import { FixedSizeList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
 import memorize from "memoize-one";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { Box, SxProps, Theme, Typography } from "@mui/material";
 
 import AppContext from "../../context/AppContext";
@@ -154,15 +154,19 @@ const SwipeableRoutesBoard = ({
             </Box>
             {availableBoardTab[index] !== "all" && (
               <Box display="flex">
-                <Typography
-                  variant="h6"
-                  sx={clickableLinkSx}
-                  onClick={() => onChangeTab("all")}
-                >
-                  {t("click-here")}
-                </Typography>
                 <Typography variant="h6">
-                  {t("to-search-all-routes")}
+                  <Trans
+                    i18nKey="click-here-to-search-all-routes"
+                    components={{
+                      ClickHereLink: (
+                        <Typography
+                          variant="h6"
+                          sx={clickableLinkSx}
+                          onClick={() => onChangeTab("all")}
+                        />
+                      ),
+                    }}
+                  />
                 </Typography>
               </Box>
             )}

--- a/src/components/route-board/SwipeableRoutesBoard.tsx
+++ b/src/components/route-board/SwipeableRoutesBoard.tsx
@@ -156,9 +156,9 @@ const SwipeableRoutesBoard = ({
               <Box display="flex">
                 <Typography variant="h6">
                   <Trans
-                    i18nKey="click-here-to-search-all-routes"
+                    i18nKey="tap-here-to-search-all-routes"
                     components={{
-                      ClickHereLink: (
+                      TapHereLink: (
                         <Typography
                           variant="h6"
                           sx={clickableLinkSx}

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -134,8 +134,8 @@ const resources = {
       ferry: "Ferry",
       "route-search-no-result": "No Result",
       "no-recent-search": "No Record",
-      "click-here": "Click here",
-      "to-search-all-routes": " to search all routes",
+      "click-here-to-search-all-routes":
+        "<ClickHereLink>Click here</ClickHereLink> to search all routes",
       對頭線: "REV",
       附近未有任何路線: "No available routes nearby",
       未有收藏路線: "No starred routes",
@@ -227,8 +227,8 @@ const resources = {
       "CTB first": "城巴優先",
       "route-search-no-result": "沒有結果",
       "no-recent-search": "沒有記錄",
-      "click-here": "按此",
-      "to-search-all-routes": "以搜尋「全部」路綫",
+      "click-here-to-search-all-routes":
+        "<ClickHereLink>按此</ClickHereLink>以搜尋「全部」路綫",
       "Source code": "原始碼",
       "We'd like to set analytics cookies that help us improve hkbus.app by measuring how you use it.":
         "我們希望設置 cookie，了解你如何使用 hkbus.app 來幫助我們改進。",

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -4,7 +4,7 @@ const resources = {
       "bad-weather-text":
         "Services may be impacted by bad weather. Data displayed below might not be accurate. Check here to see official announcements.",
       "bad-weather-link": "https://www.td.gov.hk/en/special_news/spnews.htm",
-      "db-renew-text": "Route data has not been updated, click here to update",
+      "db-renew-text": "Route data has not been updated, tap here to update",
       "巴士到站預報 App （免費無廣告）": "HK Bus ETA App (Free and Ad-free)",
       巴士到站預報: "HK BUS ETA",
       點對點路線搜尋: "Point to point route search",
@@ -134,8 +134,8 @@ const resources = {
       ferry: "Ferry",
       "route-search-no-result": "No Result",
       "no-recent-search": "No Record",
-      "click-here-to-search-all-routes":
-        "<ClickHereLink>Click here</ClickHereLink> to search all routes",
+      "tap-here-to-search-all-routes":
+        "<TapHereLink>Tap here</TapHereLink> to search all routes",
       對頭線: "REV",
       附近未有任何路線: "No available routes nearby",
       未有收藏路線: "No starred routes",
@@ -227,8 +227,8 @@ const resources = {
       "CTB first": "城巴優先",
       "route-search-no-result": "沒有結果",
       "no-recent-search": "沒有記錄",
-      "click-here-to-search-all-routes":
-        "<ClickHereLink>按此</ClickHereLink>以搜尋「全部」路綫",
+      "tap-here-to-search-all-routes":
+        "<TapHereLink>按此</TapHereLink>以搜尋「全部」路綫",
       "Source code": "原始碼",
       "We'd like to set analytics cookies that help us improve hkbus.app by measuring how you use it.":
         "我們希望設置 cookie，了解你如何使用 hkbus.app 來幫助我們改進。",


### PR DESCRIPTION
Fix from "Click hereto search all routes" to "Click here to search all routes"

1 Before:
![hkbus app_en_board(Pixel 7)](https://github.com/hkbus/hk-independent-bus-eta/assets/68117020/0c45c06c-8c39-45a2-b36b-232d6bef0717)

1 After:
![localhost_5173_en_board(Pixel 7)](https://github.com/hkbus/hk-independent-bus-eta/assets/68117020/42e7d6e2-778e-4924-be65-129d2e6884ba)

2 Before (No change):
![hkbus app_en_board(Pixel 7) (1)](https://github.com/hkbus/hk-independent-bus-eta/assets/68117020/2e69cb70-a574-4f02-8052-bd631034a382)

2 After (No change):
![localhost_5173_en_board(Pixel 7) (1)](https://github.com/hkbus/hk-independent-bus-eta/assets/68117020/e8c7fb61-477b-4f61-b1ba-484de51ba5ba)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced internationalization support by incorporating dynamic translation components.

- **Improvements**
  - Improved the localization of route search messages for better clarity and user experience. Messages now include interactive elements for a more intuitive interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->