### PR TITLE
Add automatically fit the map to the circle's bounds in RangeMap

### DIFF
--- a/src/components/home/RangeMap.tsx
+++ b/src/components/home/RangeMap.tsx
@@ -47,7 +47,12 @@ const RangeMap = React.forwardRef<Leaflet.Map, RangeMapProps>(
 
     useEffect(() => {
       const bounds = circleRef.current?.getBounds();
-      bounds && map?.fitBounds(bounds);
+      bounds &&
+        map?.fitBounds(bounds, {
+          // Disable animation to prevent not fitting to the latest bounds when called multiple times quickly
+          // See: Glitchy behavior when animating fitBounds multiple times https://github.com/Leaflet/Leaflet/issues/3249
+          animate: false,
+        });
     }, [map, range]);
 
     return (

--- a/src/components/home/RangeMap.tsx
+++ b/src/components/home/RangeMap.tsx
@@ -45,6 +45,11 @@ const RangeMap = React.forwardRef<Leaflet.Map, RangeMapProps>(
       };
     }, [handleMove, map]);
 
+    useEffect(() => {
+      const bounds = circleRef.current?.getBounds();
+      bounds && map?.fitBounds(bounds);
+    }, [map, range]);
+
     return (
       <MapContainer
         style={{ height: "100%", position: "relative" }}


### PR DESCRIPTION
As a user changes the custom search range (e.g. 175m -> 200m), the map bounds would fit accordingly automatically. The user can know how large is the range more easily.

After:
175m:
![image](https://github.com/hkbus/hk-independent-bus-eta/assets/68117020/ff97e2b1-8a13-4ef4-b587-8b3295191ca8)
200m:
![image](https://github.com/hkbus/hk-independent-bus-eta/assets/68117020/2c803707-5374-4e71-a71f-d9af4503a8dd)
4km:
![image](https://github.com/hkbus/hk-independent-bus-eta/assets/68117020/e1d0013b-8849-4741-b2e6-6caab9b12d5c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The map view on the home page now automatically adjusts based on the bounds of a circle when the `map` or `range` properties change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->