### PR TITLE
Update translation.js

### DIFF
--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -4,7 +4,7 @@ const resources = {
       "bad-weather-text":
         "Services may be impacted by bad weather. Data displayed below might not be accurate. Check here to see official announcements.",
       "bad-weather-link": "https://www.td.gov.hk/en/special_news/spnews.htm",
-      "db-renew-text": "Route info has been revised. Tap here to update.",
+      "db-renew-text": "Tap to fetch revised route info",
       "巴士到站預報 App （免費無廣告）": "HK Bus ETA App (Free and Ad-free)",
       巴士到站預報: "HK BUS ETA",
       點對點路線搜尋: "Point to point route search",

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -4,7 +4,7 @@ const resources = {
       "bad-weather-text":
         "Services may be impacted by bad weather. Data displayed below might not be accurate. Check here to see official announcements.",
       "bad-weather-link": "https://www.td.gov.hk/en/special_news/spnews.htm",
-      "db-renew-text": "Route data has not been updated, tap here to update",
+      "db-renew-text": "Route info has been revised. Tap here to update.",
       "巴士到站預報 App （免費無廣告）": "HK Bus ETA App (Free and Ad-free)",
       巴士到站預報: "HK BUS ETA",
       點對點路線搜尋: "Point to point route search",


### PR DESCRIPTION
Minor Merge Conflict between PR #188 and #189. Thus, "db-renew-text" en wordings got ambiguity again.

Change:
1. Revised "db-renew-text"  en wordings to avoid any ambiguity.
2. "Click" -> "Tap"
3. Simplify the en wordings of "db-renew-text"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved clarity of text related to updating route information. The message now reads: "Tap to fetch revised route info."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->