### PR TITLE
fix "<h6> cannot appear as a child of <h6>" arised from #189

### DIFF
--- a/src/components/route-board/SwipeableRoutesBoard.tsx
+++ b/src/components/route-board/SwipeableRoutesBoard.tsx
@@ -161,6 +161,7 @@ const SwipeableRoutesBoard = ({
                       TapHereLink: (
                         <Typography
                           variant="h6"
+                          component="span"
                           sx={clickableLinkSx}
                           onClick={() => onChangeTab("all")}
                         />


### PR DESCRIPTION
"Warning: validateDOMNesting(...): \<h6> cannot appear as a child of \<h6>."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced text styling in the `SwipeableRoutesBoard` component for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->