### PR TITLE
Group ETA on same routes with same ETA times (remote duplicate ones)

### DIFF
--- a/src/hooks/useStopEtas.tsx
+++ b/src/hooks/useStopEtas.tsx
@@ -38,7 +38,7 @@ export const useStopEtas = ({
     return (
       Object.entries(routeList)
         .reduce(
-          (acc, [routeId, { route, dest, bound, stops, freq }]) => {
+          (acc, [routeId, { route, dest, bound, stops, freq, fares }]) => {
             if (
               isRouteFilter &&
               !isRouteAvaliable(routeId, freq, isTodayHoliday, serviceDayMap)
@@ -50,7 +50,7 @@ export const useStopEtas = ({
                 if (_stopId === stopId) {
                   const hash1 = `${route}|${bound[co]??""}|${stopId}`;
                   const hash2 = `${route}|${dest.zh}|${stopId}`;
-                  const hash3 = `${route}|${seq}`;
+                  const hash3 = `${route}|${seq}|${(fares != null && seq < fares.length - 1 ? fares[seq] : 0)}`;
                   if(!hashTable.includes(hash1) && !hashTable.includes(hash2) && !hashTable.includes(hash3)) {
                     hashTable.push(hash1);
                     hashTable.push(hash2);

--- a/src/hooks/useStopEtas.tsx
+++ b/src/hooks/useStopEtas.tsx
@@ -34,10 +34,11 @@ export const useStopEtas = ({
   );
 
   const routeKeys = useMemo(() => {
+    const hashTable : Array<string> = [];
     return (
       Object.entries(routeList)
         .reduce(
-          (acc, [routeId, { stops, freq }]) => {
+          (acc, [routeId, { route, dest, bound, stops, freq }]) => {
             if (
               isRouteFilter &&
               !isRouteAvaliable(routeId, freq, isTodayHoliday, serviceDayMap)
@@ -47,7 +48,15 @@ export const useStopEtas = ({
             stopKeys.forEach(([co, stopId]) => {
               stops[co]?.forEach((_stopId, seq) => {
                 if (_stopId === stopId) {
-                  acc.push([routeId, seq]);
+                  const hash1 = `${route}|${bound[co]??""}|${stopId}`;
+                  const hash2 = `${route}|${dest.zh}|${stopId}`;
+                  const hash3 = `${route}|${seq}`;
+                  if(!hashTable.includes(hash1) && !hashTable.includes(hash2) && !hashTable.includes(hash3)) {
+                    hashTable.push(hash1);
+                    hashTable.push(hash2);
+                    hashTable.push(hash3);
+                    acc.push([routeId, seq]);
+                  }
                 }
               });
             });


### PR DESCRIPTION
### Description

This PR intends to solve issue #112.  The issue of #112 will be more obvious when multiple bus stops are merged and more ETAs are shown in the list (due to PR #193). 

Therefore, it is recommended that when merging PR #193, this PR (#194) is also merged, but these two PRs themselves have no dependencies of each other, just a recommendation.

It is also recommended to deploy to alpha site for testing first before merging to production. 

Behaviour before and after the code changes are illustrated in below screenshot.  Left side is current production build at hkbus.app, right side is my localhost version with latest code.

![image](https://github.com/user-attachments/assets/257997b8-7067-47a5-813c-fd81184f11d4)

- **Route 90B** (Rows 1 and 2)
  - ETAs are different (0, 19, 39 mins vs 0, 7, 19 mins) 
  - Direction also different (Row 1 is departure route, Row 2 is arrival route)
  - **Behavour**: no merge
- **Route 171** (Row 3 to 5 on the left)
  - ETAs are same (3, 17, 31 mins)
  - Direction also same (From South Horizon towards Lai Chi Kok)
  - **Behaviour**: merge them (criteria about which route is chosen will be described below)
  - Note: Row 9 on the right is actually arrival route, also ETA times are different (15, 25 mins). This route will not be merged.
- **Route 595** (Row 6 to 9 on the left, Row 4 to 5 on the right) 
  - ETAs with (3, 14, 29 mins) are departure route
  - ETAs with (5, 11, 15 mins) are arrival routes
  - **Behaviour**: merge departure route and show one row of ETA, then merge arrival route and show one row of ETA. Hence total two rows of route 595 on the right hand side

### Criteria to decide which route is chosen to be displayed when merging
Routes are chosen based on score system. Generally speaking, the criteria is as follows:
1. If one bus route is available according to current frequency timetable, prefer this route over the other routes that aren't running
2. If one bus route has frequency timetable and/or fares table, prefer this route over the other routes that don't have (freq/fares table = null)
3. If one bus route is normal route, others are special routes, then prefer to display the normal route (serviceType with smaller value wins)
4. If one bus route is a circular route, the other is one-way (in screenshot above, 595 海怡半島<->海怡半島 vs 595 海怡半島->石排灣), prefer the circular route (bounds with "OI" or "IO" is preferred over just "O" or "I")
At the end, the routes with best score wins and is chosen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the `useStopEtas` functionality for better filtering of stop lists and handling of duplicate routes.
  - Enhanced sorting of ETAs to display the earliest arrivals first.
  - Added logic to determine the best route based on heuristic scoring.
  - Introduced a new parameter to consider holidays in ETA calculations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->