### PR TITLE
Change light rail train length icon

### DIFF
--- a/src/components/home/SuccinctEtas.tsx
+++ b/src/components/home/SuccinctEtas.tsx
@@ -5,7 +5,6 @@ import { useEtas } from "../../hooks/useEtas";
 import AppContext from "../../context/AppContext";
 import { Eta } from "hk-bus-eta";
 import { Schedule as ScheduleIcon } from "@mui/icons-material";
-import LaptopIcon from "@mui/icons-material/Laptop";
 import useLanguage from "../../hooks/useTranslation";
 
 interface SuccinctEtasProps {

--- a/src/components/home/SuccinctEtas.tsx
+++ b/src/components/home/SuccinctEtas.tsx
@@ -122,33 +122,53 @@ const SuccinctEtas = ({
 };
 
 export const SingleTrainIcon = () => (
-  <LaptopIcon
-    sx={{
-      transform: "scaleY(-1)",
+  // https://pictogrammers.com/library/mdi/icon/train-car-passenger-door/
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    style={{
+      marginRight: 8,
+      width: "1em",
+      height: "1em",
       verticalAlign: "middle",
-      fontSize: "inherit",
-      mr: 1,
+      fill: "currentcolor",
     }}
-  />
+  >
+    <title>train-car-passenger-door</title>
+    <path d="M21 7H3C1.9 7 1 7.9 1 9V17H2C2 18.11 2.9 19 4 19S6 18.11 6 17H18C18 18.11 18.9 19 20 19S22 18.11 22 17H23V9C23 7.9 22.11 7 21 7M7 12H3V9H7V12M11 16H9V9H11V16M15 16H13V9H15V16M21 12H17V9H21V12Z" />
+  </svg>
 );
 
 export const DoubleTrainIcon = () => (
+  // https://pictogrammers.com/library/mdi/icon/train-car-passenger-door/
   <>
-    <LaptopIcon
-      sx={{
-        transform: "scaleY(-1)",
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      style={{
+        width: "1em",
+        height: "1em",
         verticalAlign: "middle",
-        fontSize: "inherit",
+        fill: "currentcolor",
       }}
-    />
-    <LaptopIcon
-      sx={{
-        transform: "scaleY(-1)",
+    >
+      <title>train-car-passenger-door</title>
+      <path d="M21 7H3C1.9 7 1 7.9 1 9V17H2C2 18.11 2.9 19 4 19S6 18.11 6 17H18C18 18.11 18.9 19 20 19S22 18.11 22 17H23V9C23 7.9 22.11 7 21 7M7 12H3V9H7V12M11 16H9V9H11V16M15 16H13V9H15V16M21 12H17V9H21V12Z" />
+    </svg>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      style={{
+        marginRight: 8,
+        width: "1em",
+        height: "1em",
         verticalAlign: "middle",
-        fontSize: "inherit",
-        mr: 1,
+        fill: "currentcolor",
       }}
-    />
+    >
+      <title>train-car-passenger-door</title>
+      <path d="M21 7H3C1.9 7 1 7.9 1 9V17H2C2 18.11 2.9 19 4 19S6 18.11 6 17H18C18 18.11 18.9 19 20 19S22 18.11 22 17H23V9C23 7.9 22.11 7 21 7M7 12H3V9H7V12M11 16H9V9H11V16M15 16H13V9H15V16M21 12H17V9H21V12Z" />
+    </svg>
   </>
 );
 


### PR DESCRIPTION


Before:
![localhost_5173_zh(Pixel 7) (1)_500w](https://github.com/user-attachments/assets/3d6a10b1-6654-478f-968f-f6bf060a8f97)

After:
![localhost_5173_zh(Pixel 7) (2)_500w](https://github.com/user-attachments/assets/6935859a-8ee8-4b91-ae75-48904ae764ea)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the visual representation of train icons for improved clarity and aesthetics. The `SingleTrainIcon` and `DoubleTrainIcon` now use SVG elements with enhanced styling properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->