### PR TITLE
Fix ETA null, Add Route Operator and Service Type Info, Reduce Duplicate Route No

### DIFF
--- a/src/components/home/SuccinctTimeReport.tsx
+++ b/src/components/home/SuccinctTimeReport.tsx
@@ -98,7 +98,7 @@ const SuccinctTimeReport = ({
   } = useContext(DbContext);
   const [routeNo] = routeId.split("-");
   const [routeKey, seq] = routeId.split("/");
-  const { co, stops, dest, fares, faresHoliday, route } =
+  const { co, stops, dest, fares, faresHoliday, route, serviceType } =
     routeList[routeKey] || DEFAULT_ROUTE;
   const stopId = getStops(co, stops)[parseInt(seq, 10)];
   const stop = stopList[stopId] || DEFAULT_STOP;
@@ -151,10 +151,22 @@ const SuccinctTimeReport = ({
       <ListItem onClick={handleClick} sx={rootSx}>
         <ListItemText
           primary={
-            <RouteNo
-              routeNo={language === "zh" ? t(routeNo) : routeNo}
-              fontSize={co[0] === "mtr" ? "1.1rem" : undefined}
-            />
+            <Box overflow="hidden">
+              <RouteNo
+                routeNo={language === "zh" ? t(routeNo) : routeNo}
+                fontSize={co[0] === "mtr" ? "1.1rem" : undefined}
+              />
+              {parseInt(serviceType, 10) >= 2 && (
+                <Typography variant="caption" sx={specialTripSx}>
+                  {t("特別班")}
+                </Typography>
+              )}
+            </Box>
+          }
+          secondary={
+            <Typography component="h4" variant="caption" sx={companySx}>
+              {co.map((co) => t(co)).join("+")}
+            </Typography>
           }
         />
         <ListItemText
@@ -268,4 +280,15 @@ const iconContainerSx: SxProps<Theme> = {
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
+};
+
+const companySx: SxProps<Theme> = {
+  color: (theme) => theme.palette.text.secondary,
+  textOverflow: "ellipsis",
+};
+
+const specialTripSx: SxProps<Theme> = {
+  color: (theme) => theme.palette.text.secondary,
+  fontSize: "0.6rem",
+  marginLeft: "8px",
 };

--- a/src/components/home/lists/NearbyRouteList.tsx
+++ b/src/components/home/lists/NearbyRouteList.tsx
@@ -129,6 +129,7 @@ const getRoutes = ({
   serviceDayMap: EtaDb["serviceDayMap"];
   searchRange: number;
 }): Partial<Record<TransportType, string>> => {
+  const addedList = [] as [string, Company, string][];
   const nearbyRoutes = Object.entries(stopList)
     .map((stop: [string, StopListEntry]): [string, StopListEntry, number] =>
       // potentially could be optimized by other distance function
@@ -149,9 +150,12 @@ const getRoutes = ({
           ).forEach((co) => {
             if (route.stops[co] && route.stops[co].includes(stopId)) {
               if (acc[coToType[co]] === undefined) acc[coToType[co]] = [];
-              acc[coToType[co]].push(
-                key + "/" + route.stops[co].indexOf(stopId)
-              );
+              if(addedList.find(([_route, _co, _serviceType]) => _route == route.route && _co == co && _serviceType < route.serviceType) === undefined) {
+                acc[coToType[co]].push(
+                  key + "/" + route.stops[co].indexOf(stopId)
+                );
+                addedList.push([route.route, co, route.serviceType]);
+              }
             }
           });
         });

--- a/src/hooks/useStopEtas.tsx
+++ b/src/hooks/useStopEtas.tsx
@@ -200,6 +200,9 @@ export const useStopEtas = ({
             )
             // sort to display the earliest arrival transport first
             .sort(([keyA, a], [keyB, b]) => {
+              a = a.filter((e) => e.eta);
+              b = b.filter((e) => e.eta);
+              if (a.length === 0 && b.length === 0) return keyA < keyB ? -1 : 1;
               if (a.length === 0) return 1;
               if (b.length === 0) return -1;
               if (isLightRail) {


### PR DESCRIPTION
### Description
This PR includes three changes (each of which is an individual commit):
1. Handle ETA may be null (and hence unable to sort ETA times) as a result of new code change in hkbus/hk-bus-eta#3 
2. Add Route Company and Service Type Info (if any) in both Stop Dialog and Home Screen (Favourites/Nearby Routes)
3. Reduce duplicate route no (hide special routes with higher service type value) in Home Screen (Nearby Routes)

The PR partially addresses some issues raised in Issue #200.  The compiled version of this PR can also be found in https://alpha.hkbus.app/ 

### Screenshots

At **Stop Dialog**
![image](https://github.com/user-attachments/assets/45786073-fddb-47a4-866e-1164e624f1eb)

At **Home Screen**
![image](https://github.com/user-attachments/assets/dbd59383-b0d9-4816-b76c-61b4805ebb37)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `serviceType` property in the time report, enhancing the display with context-specific labels.
	- Added logic to prevent duplicate route entries in the nearby routes list, improving data accuracy.

- **Bug Fixes**
	- Improved handling of empty arrays in transport sorting, ensuring robust output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->