### PR TITLE
Fix timetable current time range identification

### DIFF
--- a/src/components/route-eta/timetableDrawer/TimeTable.tsx
+++ b/src/components/route-eta/timetableDrawer/TimeTable.tsx
@@ -181,7 +181,7 @@ const isCurrentTimeslot = (
 ): boolean => {
   if (!isMatchServiceId(serviceId, isHoliday)) return false;
   const date = new Date();
-  const ts = `${date.getHours()}${date.getMinutes()}`;
+  const ts = `${date.getHours().toString().padStart(2, "0")}${date.getMinutes().toString().padStart(2, "0")}`;
   if (details) {
     return start <= ts && ts <= details[0];
   }

--- a/src/timetable.ts
+++ b/src/timetable.ts
@@ -24,9 +24,10 @@ const checkValueBetween = (
 
 export const isHoliday = (holidays: string[], date: Date): boolean => {
   return holidays.includes(
-    `${date.getFullYear()}${("0" + (date.getMonth() + 1)).slice(-2)}${(
-      "0" + date.getDate()
-    ).slice(-2)}`
+    `${date.getFullYear()}${(date.getMonth() + 1).toString().padStart(2, "0")}${date
+      .getDate()
+      .toString()
+      .padStart(2, "0")}`
   );
 };
 


### PR DESCRIPTION
**Before:**
At 2024-10-05T07:11+08:00, timetable was not highlighting. https://t.me/hkbusapp/33406
![image](https://github.com/user-attachments/assets/14147c76-2129-4f97-b5ef-2e09bca06daf)

At Sat non-public holiday 07:19 (local time zone):
![image](https://github.com/user-attachments/assets/f368428c-0a11-496b-8d64-81fbc0649852)

https://github.com/hkbus/hk-independent-bus-eta/blob/f781f7bcbfd70cb303fde9c4622a9d9bad8fc5d6/src/components/route-eta/timetableDrawer/TimeTable.tsx#L183-L187

```js
const date = new Date("2024-01-01T07:00:00+08:00");
`${date.getHours()}${date.getMinutes()}`;
// -> 70
```
The above example string `70` is compared against `start` and `details[0]`, where they are strings in the format of the 4-digit 24-hour time, e.g. `0600`, `1710`


**After:**

At Sat non-public holiday 07:19 (local time zone):
![image](https://github.com/user-attachments/assets/0ee0dfbd-129c-41e0-972d-1c13172ba3ae)

```js
const date = new Date("2024-01-01T07:00:00+08:00");
`${date.getHours().toString().padStart(2, "0")}${date.getMinutes().toString().padStart(2, "0")}`;
// -> 0700
```

Besides, code changes in `isHoliday` is just for consistency and readability




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved time formatting for current timeslot comparisons, ensuring consistency and accuracy.
	- Enhanced date formatting for holiday checks, providing clearer and more consistent date strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->