### PR TITLE
add fallback for platform character symbol ➊➋①②

### DIFF
--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -228,8 +228,8 @@ const EtaRemark = ({
   // if the remark has more than one occurrence of numerical string
   // or if the only numerical string occurrence are more than one digit, use original remark
   if (platform.length === 2 && platform[1].length) {
-    // only support single digit number
-    ret = getPlatformSymbol(Number(platform[1]), platformMode);
+    // getPlatformSymbol only supports single digit number
+    ret = getPlatformSymbol(Number(platform[1]), platformMode) ?? platform[1];
   }
 
   const trains =


### PR DESCRIPTION
Imagine when platform is a string with 2 characters, `getPlatformSymbol` returns `undefined`. This commit adds a fallback to prevent nothing is shown

https://github.com/hkbus/hk-independent-bus-eta/blob/a756a9e035288b7e26c10801ea33f6cadc1245e3/src/utils.ts#L455-L472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of platform symbols in the Time Report, ensuring valid outputs even for single-digit inputs.

- **Documentation**
	- Updated comments for clarity regarding the limitations of the `getPlatformSymbol` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->