### PR TITLE
Add handling MTR ETA API isdelay & refactor

### DIFF
--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -228,8 +228,8 @@ const EtaRemark = ({
   // if the remark has more than one occurrence of numerical string
   // or if the only numerical string occurrence are more than one digit, use original remark
   if (platform.length === 2 && platform[1].length) {
-    // only support single digit number
-    ret = getPlatformSymbol(Number(platform[1]), platformMode);
+    // getPlatformSymbol only supports single digit number
+    ret = getPlatformSymbol(Number(platform[1]), platformMode) ?? platform[1];
   }
 
   const trains =


### PR DESCRIPTION
See https://github.com/hkbus/hk-bus-eta/pull/8

This PR allows additional unrecognized mtr & lightRail ETA remarks to be rendered as is, e.g. "延誤／事故／特別服務", "Delay/ Incident/ Special Service" below.

This PR contains #206.

After (Google Pixel 7 viewport):
![image](https://github.com/user-attachments/assets/b99a821d-a527-476e-a65b-4e985363e436)
![image](https://github.com/user-attachments/assets/4c2cc501-be64-43ec-a456-7998dbd680c7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced display of train-related remarks with improved clarity and functionality.
	- Structured rendering of platform information and train symbols for better user experience.
- **Bug Fixes**
	- Corrected handling of platform numbers and ensured original remarks are retained when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->