### PR TITLE
Fix bad-weather-link & minor i18n change for bad-weather-text

### DIFF
--- a/src/components/layout/BadWeatherCard.tsx
+++ b/src/components/layout/BadWeatherCard.tsx
@@ -24,7 +24,7 @@ const BadWeatherCard = () => {
       <Paper
         variant="outlined"
         sx={rootSx}
-        onClick={() => window.open(t("bad-weather-text"), "_target")}
+        onClick={() => window.open(t("bad-weather-link"), "_target")}
       >
         <ErrorIcon color="error" />
         <Typography>{t("bad-weather-text")}</Typography>

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -2,7 +2,7 @@ const resources = {
   en: {
     translation: {
       "bad-weather-text":
-        "Services may be impacted by bad weather. Data displayed below might not be accurate. Check here to see official announcements.",
+        "Services may be impacted by bad weather. Data displayed below might not be accurate. Check here for official announcements.",
       "bad-weather-link": "https://www.td.gov.hk/en/special_news/spnews.htm",
       "db-renew-text": "Tap to fetch revised route info",
       "巴士到站預報 App （免費無廣告）": "HK Bus ETA App (Free and Ad-free)",


### PR DESCRIPTION
Before:
The bad weather alert links to
[https://hkbus.app/公共交通及班次或受惡劣天氣影響，以下資料未必反映最新狀況。按此查看官方公佈。](https://hkbus.app/%E5%85%AC%E5%85%B1%E4%BA%A4%E9%80%9A%E5%8F%8A%E7%8F%AD%E6%AC%A1%E6%88%96%E5%8F%97%E6%83%A1%E5%8A%A3%E5%A4%A9%E6%B0%A3%E5%BD%B1%E9%9F%BF%EF%BC%8C%E4%BB%A5%E4%B8%8B%E8%B3%87%E6%96%99%E6%9C%AA%E5%BF%85%E5%8F%8D%E6%98%A0%E6%9C%80%E6%96%B0%E7%8B%80%E6%B3%81%E3%80%82%E6%8C%89%E6%AD%A4%E6%9F%A5%E7%9C%8B%E5%AE%98%E6%96%B9%E5%85%AC%E4%BD%88%E3%80%82) or 
[https://hkbus.app/Services may be impacted by bad weather. Data displayed below might not be accurate. Check here to see official announcements.](https://hkbus.app/Services%20may%20be%20impacted%20by%20bad%20weather.%20Data%20displayed%20below%20might%20not%20be%20accurate.%20Check%20here%20to%20see%20official%20announcements.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Bad Weather Card to link to a new resource when clicked, enhancing user navigation.
  
- **Bug Fixes**
	- Corrected the English translation for the bad weather text for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->