### PR TITLE
Update Github workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,24 +19,17 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Cache yarn dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/.yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-          ${{ runner.os }}-
+        cache: yarn
 
-    - run: yarn install --immutable
+    - run: yarn install --frozen-lockfile
     - run: yarn run production-build
     - name: Deploy
-      uses: JamesIves/github-pages-deploy-action@v4.6.4
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages # The branch the action should deploy to.
         folder: build # The folder the action should deploy.

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,23 +16,16 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 21.x]
+        node-version: [20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Cache yarn dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/.yarn
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-          ${{ runner.os }}-
+        cache: yarn
 
-    - run: yarn install --immutable
+    - run: yarn install --frozen-lockfile
     - run: yarn run build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: yarn

--- a/.github/workflows/prettify.yml
+++ b/.github/workflows/prettify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Prettify code
         uses: creyD/prettier_action@v4.3


### PR DESCRIPTION
- Migrated away from `actions/cache@v2` as this version would fail starting Feb 1, 2025. https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/
- Fixes yarn dependency caching. The cache size is now ~563 MB instead of 45 B.
- For [Build](.github/workflows/node.js.yml) workflow, uses Node 20 & 22 instead of Node 20 & 21, as Node 22 has entered LTS since Oct 2024.
- Other updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated workflows to support newer versions of Node.js and improve dependency management.
- **Bug Fixes**
	- Enhanced caching mechanism for Yarn dependencies for better performance.
- **Chores**
	- Updated action versions in GitHub workflows to ensure compatibility and leverage improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->