### PR TITLE
Tentative fix for geolocation update issue

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -64,7 +64,8 @@ const Header = () => {
       navigator.geolocation.getCurrentPosition(
         ({ coords: { latitude, longitude } }) => {
           updateGeolocation({ lat: latitude, lng: longitude });
-        }
+        },
+        { enableHighAccuracy: true }
       );
     } catch (e) {
       console.log("error in getting location");

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -299,6 +299,7 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
             ({ coords: { latitude, longitude } }) => {
               updateGeolocation({ lat: latitude, lng: longitude });
             }
+            { enableHighAccuracy: true }
           );
           geoWatcherId.current = _geoWatcherId;
         } catch (e) {
@@ -355,7 +356,8 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
             () => {
               setGeoPermission("denied");
               if (deniedCallback) deniedCallback();
-            }
+            },
+            { enableHighAccuracy: true }
           );
           console.log(geoWatcherId.current);
         }


### PR DESCRIPTION
 **Issue:**

Geolocation stuck at old value after waking the web browser from the background

 **Observed behavior:**

`watchLocation` is being called but returned value is stuck at last location until a 3rd party app or website requested a new location

**Fix:**

Set the option `enableHighAccuracy` to true. 
Although according to MDN this will cause a slower response (https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition#enablehighaccuracy)
But the observed behavior is the opposite and actually will actually return the correct value.