### PR TITLE
Update notice.json

### DIFF
--- a/public/notice.json
+++ b/public/notice.json
@@ -1,13 +1,13 @@
 {
   "content": {
     "zh": [
-      "1 月 5 日最新票價資料有待運輸署更新開放數據"
+      "香港馬拉松 2025 特別交通安排"
     ],
     "en": [
-      "Updated fares info from 5/1 to be updated by the Transport Department's open data."
+      "Special Traffic and Transport Arrangements for the Hong Kong Marathon 2025"
     ]
   },
-  "url": "https://www.td.gov.hk/tc/traffic_notices/index_id_78709.html",
+  "url": "https://www.td.gov.hk/tc/traffic_notices/index_id_79146.html",
   "enableLinkInIos": true,
-  "isShown": false
+  "isShown": true
 }


### PR DESCRIPTION
for Hong Kong Marathon 2025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The traffic notice now displays updated information regarding special traffic arrangements for the Hong Kong Marathon 2025.
  - Both Chinese and English content have been revised to reflect the new message.
  - The reference link has been updated, and the notice is now set to be visible to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->