### PR TITLE
Enhance inputpad usability on smaller screens

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -114,7 +114,7 @@ const Header = () => {
       setIsSearching(false);
       prevPathRef.current = location.pathname;
     }
-  }, [location.pathname]);
+  }, [location.pathname, setIsSearching]);
 
   const handleInputClick = (e: React.MouseEvent) => {
     if (!inputref.current) return;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useContext } from "react";
+import { useEffect, useCallback, useContext, useRef } from "react";
 import {
   Avatar,
   Box,
@@ -51,6 +51,7 @@ const Header = () => {
   const navigate = useNavigate();
   const weatherCodes = useWeatherCode();
   const onlineStatus = useOnline();
+  const inputref = useRef<HTMLInputElement>(null);
 
   const handleLanguageChange = (lang: "zh" | "en") => {
     vibrate(vibrateDuration);
@@ -102,6 +103,19 @@ const Header = () => {
     };
   }, [handleKeydown]);
 
+  const handleInputClick = (e: React.MouseEvent) => {
+    if (!inputref.current) return;
+    e.preventDefault();
+    console.log("input clicked");
+    if (isSearching) {
+      inputref.current.blur();
+      setIsSearching(false);
+    } else {
+      inputref.current.focus();
+      setIsSearching(!isSearching);
+    }
+  };
+
   return (
     <Toolbar sx={rootSx}>
       <Link
@@ -127,6 +141,7 @@ const Header = () => {
         id="searchInput"
         sx={searchRouteInputSx}
         type="text"
+        ref={inputref}
         value={searchRoute}
         placeholder={t("路線")}
         startAdornment={
@@ -149,9 +164,9 @@ const Header = () => {
           }
           setSearchRoute(e.target.value);
         }}
+        onClick={handleInputClick}
         onFocus={() => {
           vibrate(vibrateDuration);
-          setIsSearching(true);
           if (navigator.userAgent !== "prerendering" && checkMobile()) {
             (document.activeElement as HTMLElement).blur();
           }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -106,7 +106,6 @@ const Header = () => {
   const handleInputClick = (e: React.MouseEvent) => {
     if (!inputref.current) return;
     e.preventDefault();
-    console.log("input clicked");
     if (isSearching) {
       inputref.current.blur();
       setIsSearching(false);

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -52,6 +52,8 @@ const Header = () => {
   const weatherCodes = useWeatherCode();
   const onlineStatus = useOnline();
   const inputref = useRef<HTMLInputElement>(null);
+  const prevPathRef = useRef<string>(location.pathname);
+  const SwitchedTab = useRef<boolean>(false);
 
   const handleLanguageChange = (lang: "zh" | "en") => {
     vibrate(vibrateDuration);
@@ -103,9 +105,35 @@ const Header = () => {
     };
   }, [handleKeydown]);
 
+  /**
+   *  Detect if the previous path is different (i.e "/board")
+   */
+  useEffect(() => {
+    if (prevPathRef.current !== location.pathname) {
+      SwitchedTab.current = true;
+      setIsSearching(false);
+      prevPathRef.current = location.pathname;
+    }
+  }, [location.pathname]);
+
   const handleInputClick = (e: React.MouseEvent) => {
     if (!inputref.current) return;
     e.preventDefault();
+
+    // If the user has switched tabs, turn on keypad
+    if (SwitchedTab.current) {
+      SwitchedTab.current = false;
+      if (isSearching) {
+        inputref.current.blur();
+        setIsSearching(false);
+      } else {
+        inputref.current.focus();
+        setIsSearching(true);
+      }
+      return;
+    }
+
+    // Turning on/off the keypad
     if (isSearching) {
       inputref.current.blur();
       setIsSearching(false);

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -39,6 +39,8 @@ const Header = () => {
     changeLanguage,
     _colorMode,
     toggleColorMode,
+    isSearching,
+    setIsSearching,
   } = useContext(AppContext);
   const {
     db: { routeList },
@@ -127,7 +129,16 @@ const Header = () => {
         type="text"
         value={searchRoute}
         placeholder={t("路線")}
-        startAdornment={<SearchIcon fontSize="small" sx={{ opacity: 0.8 }} />}
+        startAdornment={
+          <Box
+            onClick={() => {
+              setIsSearching(!isSearching);
+            }}
+            sx={{ display: "flex", alignItems: "center", cursor: "pointer" }}
+          >
+            <SearchIcon fontSize="small" sx={{ opacity: 0.8 }} />
+          </Box>
+        }
         onChange={(e) => {
           if (
             e.target.value.toUpperCase() in routeList ||
@@ -140,6 +151,7 @@ const Header = () => {
         }}
         onFocus={() => {
           vibrate(vibrateDuration);
+          setIsSearching(true);
           if (navigator.userAgent !== "prerendering" && checkMobile()) {
             (document.activeElement as HTMLElement).blur();
           }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -51,9 +51,9 @@ const Header = () => {
   const navigate = useNavigate();
   const weatherCodes = useWeatherCode();
   const onlineStatus = useOnline();
-  const inputref = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const prevPathRef = useRef<string>(location.pathname);
-  const SwitchedTab = useRef<boolean>(false);
+  const switchedTab = useRef<boolean>(false);
 
   const handleLanguageChange = (lang: "zh" | "en") => {
     vibrate(vibrateDuration);
@@ -110,36 +110,29 @@ const Header = () => {
    */
   useEffect(() => {
     if (prevPathRef.current !== location.pathname) {
-      SwitchedTab.current = true;
+      switchedTab.current = true;
       setIsSearching(false);
       prevPathRef.current = location.pathname;
     }
   }, [location.pathname, setIsSearching]);
 
-  const handleInputClick = (e: React.MouseEvent) => {
-    if (!inputref.current) return;
-    e.preventDefault();
+  const handleInputClick = () => {
+    if (!inputRef.current) return;
 
     // If the user has switched tabs, turn on keypad
-    if (SwitchedTab.current) {
-      SwitchedTab.current = false;
-      if (isSearching) {
-        inputref.current.blur();
-        setIsSearching(false);
-      } else {
-        inputref.current.focus();
-        setIsSearching(true);
-      }
+    if (switchedTab.current) {
+      switchedTab.current = false;
+      inputRef.current.focus();
+      setIsSearching(true);
       return;
     }
-
     // Turning on/off the keypad
     if (isSearching) {
-      inputref.current.blur();
+      inputRef.current.blur();
       setIsSearching(false);
     } else {
-      inputref.current.focus();
-      setIsSearching(!isSearching);
+      inputRef.current.focus();
+      setIsSearching(true);
     }
   };
 
@@ -168,7 +161,7 @@ const Header = () => {
         id="searchInput"
         sx={searchRouteInputSx}
         type="text"
-        ref={inputref}
+        ref={inputRef}
         value={searchRoute}
         placeholder={t("路線")}
         startAdornment={
@@ -177,6 +170,9 @@ const Header = () => {
               setIsSearching(!isSearching);
             }}
             sx={{ display: "flex", alignItems: "center", cursor: "pointer" }}
+            role="button"
+            aria-label="Search Route"
+            tabIndex={0}
           >
             <SearchIcon fontSize="small" sx={{ opacity: 0.8 }} />
           </Box>

--- a/src/components/route-board/RouteInputPad.tsx
+++ b/src/components/route-board/RouteInputPad.tsx
@@ -114,7 +114,9 @@ const rootSx: SxProps<Theme> = {
   flexDirection: "row",
   // TODO: increase to 258px or enable scroll
   height: "248px",
+  minHeight: "62px",
   justifyContent: "space-around",
+  overflow: "hidden",
 };
 
 const buttonSx: SxProps<Theme> = {
@@ -141,13 +143,16 @@ const alphabetSx: SxProps<Theme> = {
 
 const alphabetPadContainerSx: SxProps<Theme> = {
   width: "35%",
-  height: "246px",
+  height: "auto",
   overflowX: "hidden",
   overflowY: "scroll",
 };
 
 const numPadContainerSx: SxProps<Theme> = {
   width: "62%",
+  height: "auto",
+  overflowX: "hidden",
+  overflowY: "scroll",
 };
 
 const getPossibleChar = (

--- a/src/components/route-board/SwipeableRoutesBoard.tsx
+++ b/src/components/route-board/SwipeableRoutesBoard.tsx
@@ -129,62 +129,68 @@ const SwipeableRoutesBoard = ({
             )}
           </AutoSizer>
         ) : (
-          <Box sx={noResultSx}>
-            <Box
-              display="flex"
-              alignItems="center"
-              flexDirection="column"
-              gap={1}
-            >
-              {availableBoardTab[index] !== "recent" ? (
-                <>
-                  <Box display="flex" alignItems="center">
-                    <SentimentVeryDissatisfiedIcon fontSize="small" />
-                    <Typography variant="h6">
-                      &quot;{searchRoute}&quot;
-                    </Typography>
-                    <Typography variant="h6">
-                      {t("route-search-no-result")}
-                    </Typography>
-                  </Box>
-                  <Typography variant="body1">
-                    {t("suggest-update-database")}
-                  </Typography>
-                </>
-              ) : (
-                <Box display="flex" alignItems="center" gap={2}>
-                  <Box display="flex" alignItems="center">
-                    <SentimentVeryDissatisfiedIcon fontSize="small" />
-                    {searchRoute.length > 0 && (
-                      <Typography variant="h6">
-                        &quot;{searchRoute}&quot;
+          <AutoSizer>
+            {({ width }) => (
+              <Box sx={noResultSx} width={width}>
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  flexDirection="column"
+                  gap={1}
+                >
+                  {availableBoardTab[index] !== "recent" ? (
+                    <>
+                      <Box display="flex" alignItems="center">
+                        <SentimentVeryDissatisfiedIcon fontSize="small" />
+                        <Typography variant="h6">
+                          &quot;{searchRoute}&quot;
+                        </Typography>
+                        <Typography variant="h6">
+                          {t("route-search-no-result")}
+                        </Typography>
+                      </Box>
+                      <Typography variant="body1">
+                        {t("suggest-update-database")}
                       </Typography>
-                    )}
-                  </Box>
-                  <Typography variant="h6">{t("no-recent-search")}</Typography>
+                    </>
+                  ) : (
+                    <Box display="flex" alignItems="center" gap={2}>
+                      <Box display="flex" alignItems="center">
+                        <SentimentVeryDissatisfiedIcon fontSize="small" />
+                        {searchRoute.length > 0 && (
+                          <Typography variant="h6">
+                            &quot;{searchRoute}&quot;
+                          </Typography>
+                        )}
+                      </Box>
+                      <Typography variant="h6">
+                        {t("no-recent-search")}
+                      </Typography>
+                    </Box>
+                  )}
                 </Box>
-              )}
-            </Box>
-            {availableBoardTab[index] !== "all" && (
-              <Box display="flex">
-                <Typography variant="h6">
-                  <Trans
-                    i18nKey="tap-here-to-search-all-routes"
-                    components={{
-                      TapHereLink: (
-                        <Typography
-                          variant="h6"
-                          component="span"
-                          sx={clickableLinkSx}
-                          onClick={() => onChangeTab("all")}
-                        />
-                      ),
-                    }}
-                  />
-                </Typography>
+                {availableBoardTab[index] !== "all" && (
+                  <Box display="flex">
+                    <Typography variant="h6">
+                      <Trans
+                        i18nKey="tap-here-to-search-all-routes"
+                        components={{
+                          TapHereLink: (
+                            <Typography
+                              variant="h6"
+                              component="span"
+                              sx={clickableLinkSx}
+                              onClick={() => onChangeTab("all")}
+                            />
+                          ),
+                        }}
+                      />
+                    </Typography>
+                  </Box>
+                )}
               </Box>
             )}
-          </Box>
+          </AutoSizer>
         )}
       </React.Fragment>
     ),

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -100,6 +100,10 @@ export interface AppState {
    * Range for home page nearby search
    */
   searchRange: number;
+  /**
+   * Is input currently being entered
+   */
+  isSearching: boolean;
 }
 
 interface AppContextValue extends AppState {
@@ -136,6 +140,7 @@ interface AppContextValue extends AppState {
   setFontSize: (fontSize: number) => void;
   importAppState: (appState: AppState) => void;
   setSearchRange: (searchRange: number) => void;
+  setIsSearching: (searching: boolean) => void;
 
   // for React Native Context
   setGeoPermission: (geoPermission: AppState["geoPermission"]) => void;
@@ -260,6 +265,7 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
       searchRange: JSON.parse(
         localStorage.getItem("searchRange") ?? `${DEFAULT_SEARCH_RANGE}`
       ),
+      isSearching: true,
     };
   };
   const geolocation = useRef<GeoLocation>(_geolocation);
@@ -596,6 +602,14 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
     );
   }, []);
 
+  const setIsSearching = useCallback((searching: boolean) => {
+    setStateRaw(
+      produce((state: State) => {
+        state.isSearching = searching;
+      })
+    );
+  }, []);
+
   const calculateColorMode = useCallback(() => {
     if (state._colorMode === "light" || state._colorMode === "dark") {
       return state._colorMode;
@@ -776,6 +790,7 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
       importAppState,
       setGeoPermission,
       setSearchRange,
+      setIsSearching,
     }),
     [
       state,
@@ -807,6 +822,7 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
       importAppState,
       setGeoPermission,
       setSearchRange,
+      setIsSearching,
     ]
   );
 

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -265,7 +265,7 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
       searchRange: JSON.parse(
         localStorage.getItem("searchRange") ?? `${DEFAULT_SEARCH_RANGE}`
       ),
-      isSearching: true,
+      isSearching: false,
     };
   };
   const geolocation = useRef<GeoLocation>(_geolocation);

--- a/src/pages/DataImport.tsx
+++ b/src/pages/DataImport.tsx
@@ -121,6 +121,7 @@ const DataImport = () => {
       isRecentSearchShown: obj.isRecentSearchShown ?? true,
       fontSize: obj.fontSize ?? 16,
       searchRange: obj.searchRange ?? DEFAULT_SEARCH_RANGE,
+      isSearching: obj.isSearching ?? false,
     });
 
     navigate("/");

--- a/src/pages/RouteBoard.tsx
+++ b/src/pages/RouteBoard.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState, useCallback } from "react";
 import AppContext from "../context/AppContext";
-import { Box, Slide } from "@mui/material";
+import { Box } from "@mui/material";
 import RouteInputPad from "../components/route-board/RouteInputPad";
 import { useTranslation } from "react-i18next";
 import { setSeoHeader } from "../utils";
@@ -83,24 +83,17 @@ const RouteBoard = () => {
       >
         <RouteList boardTab={boardTab} setBoardTab={setBoardTab} />
       </Box>
-      <Slide
-        direction="up"
-        in={windowHeight > 525 || isSearching}
-        mountOnEnter
-        unmountOnExit
+      <Box
+        sx={{
+          height: "auto",
+          maxHeight: "100%",
+          display: windowHeight > 525 || isSearching ? "flex" : "none",
+          flexDirection: "column",
+          overflowY: "scroll",
+        }}
       >
-        <Box
-          sx={{
-            height: "auto",
-            maxHeight: "100%",
-            display: "flex",
-            flexDirection: "column",
-            overflowY: "scroll",
-          }}
-        >
-          <RouteInputPad boardTab={boardTab} />
-        </Box>
-      </Slide>
+        <RouteInputPad boardTab={boardTab} />
+      </Box>
     </Box>
   );
 };

--- a/src/pages/RouteBoard.tsx
+++ b/src/pages/RouteBoard.tsx
@@ -57,6 +57,13 @@ const RouteBoard = () => {
   const [boardTab, setBoardTab] = useState<BoardTabType>(
     isBoardTab(_boardTab, isRecentSearchShown) ? _boardTab : "all"
   );
+  const [windowHeight, setWindowHeight] = useState(window.innerHeight);
+
+  useEffect(() => {
+    const handleResize = () => setWindowHeight(window.innerHeight);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   return (
     <Box
@@ -78,7 +85,7 @@ const RouteBoard = () => {
       </Box>
       <Slide
         direction="up"
-        in={window.innerHeight > 460 || isSearching}
+        in={windowHeight > 525 || isSearching}
         mountOnEnter
         unmountOnExit
       >

--- a/src/pages/RouteBoard.tsx
+++ b/src/pages/RouteBoard.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState, useCallback } from "react";
 import AppContext from "../context/AppContext";
-import { Box } from "@mui/material";
+import { Box, Slide } from "@mui/material";
 import RouteInputPad from "../components/route-board/RouteInputPad";
 import { useTranslation } from "react-i18next";
 import { setSeoHeader } from "../utils";
@@ -38,7 +38,13 @@ const RouteList = ({ boardTab, setBoardTab }: RouteListProps) => {
   );
 
   return (
-    <Box sx={{ flex: 1, display: "flex", flexDirection: "column" }}>
+    <Box
+      sx={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
       <BoardTabbar boardTab={boardTab} onChangeTab={handleTabChange} />
       <SwipeableRoutesBoard boardTab={boardTab} onChangeTab={handleTabChange} />
     </Box>
@@ -46,17 +52,49 @@ const RouteList = ({ boardTab, setBoardTab }: RouteListProps) => {
 };
 
 const RouteBoard = () => {
-  const { isRecentSearchShown } = useContext(AppContext);
+  const { isRecentSearchShown, isSearching } = useContext(AppContext);
   const _boardTab = localStorage.getItem("boardTab");
   const [boardTab, setBoardTab] = useState<BoardTabType>(
     isBoardTab(_boardTab, isRecentSearchShown) ? _boardTab : "all"
   );
 
   return (
-    <>
-      <RouteList boardTab={boardTab} setBoardTab={setBoardTab} />
-      <RouteInputPad boardTab={boardTab} />
-    </>
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+      }}
+    >
+      <Box
+        sx={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          overflowY: "scroll",
+        }}
+      >
+        <RouteList boardTab={boardTab} setBoardTab={setBoardTab} />
+      </Box>
+      <Slide
+        direction="up"
+        in={window.innerHeight > 460 || isSearching}
+        mountOnEnter
+        unmountOnExit
+      >
+        <Box
+          sx={{
+            height: "auto",
+            maxHeight: "100%",
+            display: "flex",
+            flexDirection: "column",
+            overflowY: "scroll",
+          }}
+        >
+          <RouteInputPad boardTab={boardTab} />
+        </Box>
+      </Slide>
+    </Box>
   );
 };
 


### PR DESCRIPTION
This PR fixes an issue affecting smaller screens / split-screen mode where the inputpad cannot display all buttons.

## Issue Fixed:

- Resolved #124 
- On smaller screens, some inputpad buttons were missing, preventing users from searching for their route number.
- This fix allows the inputpad to use as much space as it can and hides itself when users complete input.

![Screenshot 2025-06-01 164457](https://github.com/user-attachments/assets/51e8ff98-a6c5-497a-aa44-e536adc94972)
- In some extreme cases, the number pad may now be scrollable.

![Screenshot 2025-06-01 164756](https://github.com/user-attachments/assets/77c48860-b808-4033-a6f7-18fa11fe2b8f)
- Fixed a positioning issue where the invalid result message (i.e route-search-no-result) shifted sideways when input was too long (entered via physical keyboard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Search input in the header now gains and loses focus more intuitively, especially when switching tabs or navigating between pages.
	- The app tracks and manages the active state of the search input for a smoother user experience.

- **Improvements**
	- Route input pads now adjust their height dynamically and offer improved scrolling behavior.
	- "No results" messages in route lists now adapt responsively to screen width.
	- The route input pad is hidden on smaller screens unless the search input is active, optimizing space usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->