### PR TITLE
Fix missing light rail map route path 

### DIFF
--- a/src/hooks/useRoutePath.tsx
+++ b/src/hooks/useRoutePath.tsx
@@ -17,7 +17,7 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
   const {
     db: { routeList },
   } = useContext(DbContext);
-  const { gtfsId, bound, co } = routeList[routeId];
+  const { gtfsId, bound, co, route, dest } = routeList[routeId];
 
   useEffect(() => {
     let waypointsFile = "";
@@ -27,6 +27,9 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
       }.json`;
     } else if (co.includes("mtr")) {
       waypointsFile = `${routeId.split("-")[0].toLowerCase()}.json`;
+    } else if (route && co.includes("lightRail")) {
+      // For light rail map
+      waypointsFile = `${route}${dest.en.includes("Circular") ? "" : bound[co[0]] === "I" ? "_I" : "_O"}.json`;
     }
     fetch(`https://hkbus.github.io/route-waypoints/${waypointsFile}`)
       .then((r) => r.json())
@@ -56,7 +59,7 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
     return () => {
       setGeoJson(null);
     };
-  }, [routeId, gtfsId, bound, co, stops]);
+  }, [routeId, gtfsId, bound, co, stops, dest, route]);
 
   return geoJson;
 };


### PR DESCRIPTION
This PR fixes an issue where Light Rail map was unable to locate waypoint files due to gtfsId values not being applicable.

## Bug Fixes:

- The Light Rail map now displays a more accurate route path instead of a straight line between stops.

![Screenshot 2025-06-08 221030](https://github.com/user-attachments/assets/18cf0339-2187-40c8-ac06-c70b991527fb)

## Follow up

- Waypoint files for lrtfeeder route are unavailable.
-  #149 For NLB routes, the problem seems to be coming from crawling, where the bound is always set to "O", causing "I" files to be unused. Also, API results appear to be unsorted as well as the waypoint files. So, it might be best for you to sort them manually, as I am unsure of the correct bound for each route.

https://github.com/hkbus/hk-bus-crawling/blob/6bbaee777e00d5d4529d19d9cff926187268d3f8/crawling/nlb.py#L27C1-L39C9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of certain light rail routes to ensure correct waypoint files are loaded based on route and destination details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->