### PR TITLE
Enhance tabbar usability

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,3 +41,7 @@ body {
     transform: rotate(360deg);
   }
 }
+
+.Mui-selected {
+  font-weight: 700 !important;
+}

--- a/src/components/bookmarked-stop/StopTabbar.tsx
+++ b/src/components/bookmarked-stop/StopTabbar.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import useLanguage from "../../hooks/useTranslation";
 import CollectionContext from "../../CollectionContext";
 import DbContext from "../../context/DbContext";
+import { useHorizontalWheelScroll } from "../../hooks/useHorizontalWheelScroll";
 
 interface HomeTabbarProps {
   stopTab: string | null;
@@ -17,6 +18,8 @@ const StopTabbar = ({ stopTab, onChangeTab }: HomeTabbarProps) => {
   const {
     db: { stopList },
   } = useContext(DbContext);
+
+  useHorizontalWheelScroll();
 
   if (savedStops.length === 0) {
     return (
@@ -34,6 +37,7 @@ const StopTabbar = ({ stopTab, onChangeTab }: HomeTabbarProps) => {
       sx={tabbarSx}
       variant="scrollable"
       scrollButtons
+      allowScrollButtonsMobile
     >
       {savedStops
         .map((stopId) => stopId.split("|"))

--- a/src/components/home/HomeTabbar.tsx
+++ b/src/components/home/HomeTabbar.tsx
@@ -44,6 +44,7 @@ const HomeTabbar = ({ homeTab, onChangeTab }: HomeTabbarProps) => {
       sx={tabbarSx}
       variant="scrollable"
       scrollButtons
+      allowScrollButtonsMobile
     >
       <Tab
         iconPosition="start"
@@ -116,8 +117,5 @@ const tabbarSx: SxProps<Theme> = {
     "& .MuiTab-root": {
       fontSize: "0.8em",
     },
-  },
-  [`& .Mui-selected`]: {
-    fontWeight: 700,
   },
 };

--- a/src/components/home/HomeTabbar.tsx
+++ b/src/components/home/HomeTabbar.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { Tabs, Tab, SxProps, Theme } from "@mui/material";
 import {
   Star as StarIcon,
@@ -17,6 +17,25 @@ interface HomeTabbarProps {
 const HomeTabbar = ({ homeTab, onChangeTab }: HomeTabbarProps) => {
   const { t } = useTranslation();
   const { collections } = useContext(CollectionContext);
+
+  useEffect(() => {
+    // Enable horizontal scroll with mouse wheel (PC)
+    const tabsScroller = document.querySelector(".MuiTabs-scroller");
+
+    const handleWheel = (event: Event) => {
+      const wheelEvent = event as WheelEvent;
+      if (wheelEvent.deltaY !== 0) {
+        wheelEvent.preventDefault();
+        if (tabsScroller) {
+          tabsScroller.scrollLeft += wheelEvent.deltaY * 0.3;
+        }
+      }
+    };
+    tabsScroller?.addEventListener("wheel", handleWheel);
+    return () => {
+      tabsScroller?.removeEventListener("wheel", handleWheel);
+    };
+  }, []);
 
   return (
     <Tabs

--- a/src/components/home/HomeTabbar.tsx
+++ b/src/components/home/HomeTabbar.tsx
@@ -117,4 +117,7 @@ const tabbarSx: SxProps<Theme> = {
       fontSize: "0.8em",
     },
   },
+  [`& .Mui-selected`]: {
+    fontWeight: 700,
+  },
 };

--- a/src/components/home/HomeTabbar.tsx
+++ b/src/components/home/HomeTabbar.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import { Tabs, Tab, SxProps, Theme } from "@mui/material";
 import {
   Star as StarIcon,
@@ -8,6 +8,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { RouteCollection } from "../../@types/types";
 import CollectionContext from "../../CollectionContext";
+import { useHorizontalWheelScroll } from "../../hooks/useHorizontalWheelScroll";
 
 interface HomeTabbarProps {
   homeTab: HomeTabType | string;
@@ -17,25 +18,7 @@ interface HomeTabbarProps {
 const HomeTabbar = ({ homeTab, onChangeTab }: HomeTabbarProps) => {
   const { t } = useTranslation();
   const { collections } = useContext(CollectionContext);
-
-  useEffect(() => {
-    // Enable horizontal scroll with mouse wheel (PC)
-    const tabsScroller = document.querySelector(".MuiTabs-scroller");
-
-    const handleWheel = (event: Event) => {
-      const wheelEvent = event as WheelEvent;
-      if (wheelEvent.deltaY !== 0) {
-        wheelEvent.preventDefault();
-        if (tabsScroller) {
-          tabsScroller.scrollLeft += wheelEvent.deltaY * 0.3;
-        }
-      }
-    };
-    tabsScroller?.addEventListener("wheel", handleWheel);
-    return () => {
-      tabsScroller?.removeEventListener("wheel", handleWheel);
-    };
-  }, []);
+  useHorizontalWheelScroll();
 
   return (
     <Tabs

--- a/src/components/route-board/BoardTabbar.tsx
+++ b/src/components/route-board/BoardTabbar.tsx
@@ -41,7 +41,8 @@ const BoardTabbar = ({ boardTab, onChangeTab }: BoardTabbarProps) => {
         onChange={(_, v) => onChangeTab(v, true)}
         sx={tabbarSx}
         variant="scrollable"
-        scrollButtons={true}
+        scrollButtons
+        allowScrollButtonsMobile
       >
         {Object.keys(TRANSPORT_SEARCH_OPTIONS)
           .filter((option) => isRecentSearchShown || option !== "recent")
@@ -85,8 +86,5 @@ const tabbarSx: SxProps<Theme> = {
   },
   [`& .MuiTabs-scroller`]: {
     overflow: "auto !important",
-  },
-  [`& .Mui-selected`]: {
-    fontWeight: 700,
   },
 };

--- a/src/components/route-board/BoardTabbar.tsx
+++ b/src/components/route-board/BoardTabbar.tsx
@@ -86,4 +86,7 @@ const tabbarSx: SxProps<Theme> = {
   [`& .MuiTabs-scroller`]: {
     overflow: "auto !important",
   },
+  [`& .Mui-selected`]: {
+    fontWeight: 700,
+  },
 };

--- a/src/components/route-board/BoardTabbar.tsx
+++ b/src/components/route-board/BoardTabbar.tsx
@@ -1,10 +1,11 @@
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import { Box, Tabs, Tab, SxProps, Theme } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 import { TRANSPORT_SEARCH_OPTIONS } from "../../constants";
 import AppContext from "../../context/AppContext";
 import { BoardTabType } from "../../@types/types";
+import { useHorizontalWheelScroll } from "../../hooks/useHorizontalWheelScroll";
 
 interface BoardTabbarProps {
   boardTab: BoardTabType;
@@ -14,25 +15,7 @@ interface BoardTabbarProps {
 const BoardTabbar = ({ boardTab, onChangeTab }: BoardTabbarProps) => {
   const { t } = useTranslation();
   const { isRecentSearchShown } = useContext(AppContext);
-
-  useEffect(() => {
-    // Enable horizontal scroll with mouse wheel (PC)
-    const tabsScroller = document.querySelector(".MuiTabs-scroller");
-
-    const handleWheel = (event: Event) => {
-      const wheelEvent = event as WheelEvent;
-      if (wheelEvent.deltaY !== 0) {
-        wheelEvent.preventDefault();
-        if (tabsScroller) {
-          tabsScroller.scrollLeft += wheelEvent.deltaY * 0.3;
-        }
-      }
-    };
-    tabsScroller?.addEventListener("wheel", handleWheel);
-    return () => {
-      tabsScroller?.removeEventListener("wheel", handleWheel);
-    };
-  }, []);
+  useHorizontalWheelScroll();
 
   return (
     <Box>

--- a/src/components/route-board/BoardTabbar.tsx
+++ b/src/components/route-board/BoardTabbar.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { Box, Tabs, Tab, SxProps, Theme } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
@@ -15,12 +15,33 @@ const BoardTabbar = ({ boardTab, onChangeTab }: BoardTabbarProps) => {
   const { t } = useTranslation();
   const { isRecentSearchShown } = useContext(AppContext);
 
+  useEffect(() => {
+    // Enable horizontal scroll with mouse wheel (PC)
+    const tabsScroller = document.querySelector(".MuiTabs-scroller");
+
+    const handleWheel = (event: Event) => {
+      const wheelEvent = event as WheelEvent;
+      if (wheelEvent.deltaY !== 0) {
+        wheelEvent.preventDefault();
+        if (tabsScroller) {
+          tabsScroller.scrollLeft += wheelEvent.deltaY * 0.3;
+        }
+      }
+    };
+    tabsScroller?.addEventListener("wheel", handleWheel);
+    return () => {
+      tabsScroller?.removeEventListener("wheel", handleWheel);
+    };
+  }, []);
+
   return (
     <Box>
       <Tabs
         value={boardTab}
         onChange={(_, v) => onChangeTab(v, true)}
         sx={tabbarSx}
+        variant="scrollable"
+        scrollButtons={true}
       >
         {Object.keys(TRANSPORT_SEARCH_OPTIONS)
           .filter((option) => isRecentSearchShown || option !== "recent")

--- a/src/components/route-eta/StopDialog.tsx
+++ b/src/components/route-eta/StopDialog.tsx
@@ -43,6 +43,22 @@ const StopDialog = ({ open, stops, onClose }: StopDialogProps) => {
     [stops, savedStops]
   );
 
+  const updateBookmark = useCallback(
+    (dialogStop: [Company, string]) => {
+      // Find the savedStop in localhost related to dialogStops and update
+      const bookmarkedStop = stops.find((stop) =>
+        savedStops.includes(stop.join("|"))
+      );
+
+      if (bookmarkedStop) {
+        updateSavedStops(bookmarkedStop.join("|"));
+      } else {
+        updateSavedStops(dialogStop.join("|"));
+      }
+    },
+    [savedStops, stops, updateSavedStops]
+  );
+
   const handleClickDirection = useCallback(() => {
     if (stopList[stops[0][1]]?.location) {
       const { lat, lng } = stopList[stops[0][1]].location;
@@ -64,7 +80,7 @@ const StopDialog = ({ open, stops, onClose }: StopDialogProps) => {
     <Dialog open={open} onClose={onClose} sx={rootSx}>
       <DialogTitle sx={titleSx}>
         <Box>
-          <IconButton onClick={() => updateSavedStops(stops[0].join("|"))}>
+          <IconButton onClick={() => updateBookmark(stops[0])}>
             {bookmarked ? <BookmarkIcon /> : <BookmarkBorderIcon />}
           </IconButton>
           {stopList[stops[0][1]]?.name[language]}

--- a/src/hooks/useHorizontalWheelScroll.tsx
+++ b/src/hooks/useHorizontalWheelScroll.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+// Enable horizontal scroll with mouse wheel for MUI tab (PC - without shift+scroll)
+
+export function useHorizontalWheelScroll(
+  selector: string = ".MuiTabs-scroller",
+  speed = 0.3
+) {
+  useEffect(() => {
+    const scroller = document.querySelector(selector);
+    if (!scroller) return;
+    const handleWheel = (event: Event) => {
+      const wheelEvent = event as WheelEvent;
+      if (wheelEvent.deltaY !== 0) {
+        wheelEvent.preventDefault();
+        scroller.scrollLeft += wheelEvent.deltaY * speed;
+      }
+    };
+    scroller.addEventListener("wheel", handleWheel, { passive: false });
+    return () => {
+      scroller.removeEventListener("wheel", handleWheel);
+    };
+  }, [selector, speed]);
+}


### PR DESCRIPTION
This PR improve navigation for using the tabbar and fixes a bug with bookmarked stops

# Improvement

- Tabbar scroll buttons are now consistently visible across all pages, improving accessibility on some screen sizes. (Some tabs were quite hidden)
- Enabled horizontal scrolling via mouse wheel (MUI only have `Shift + Scroll`).
- Increased font-weight for selected tab.
<img width="892" height="475" alt="Screenshot 2025-09-13 195556" src="https://github.com/user-attachments/assets/63a9f014-8c7a-4dc1-8fd0-ae928f0557fb" />

# Bug fixes

- Fixed an issue where bookmarked stops could not be unbookmarked in some cases. This occurred when stops had differing IDs across routes/companies but appeared in the same `StopDialog`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Tab bars now support horizontal scrolling with the mouse wheel.
  * Scroll buttons are shown on mobile for easier tab navigation.
  * Route board tabs are scrollable with visible controls.

* Bug Fixes
  * Bookmarking in the stop dialog now preserves the existing saved stop, keeping the bookmark indicator accurate.

* Style
  * Selected tabs appear bold for clearer visual emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->