### PR TITLE
Fix undefined eta dest causing crash

### DIFF
--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -121,7 +121,7 @@ const EtaLine = ({
       return true;
     }
     for (const routeDest of routeDests) {
-      if (routeDest.en.toLowerCase() === dest.en.toLowerCase()) {
+      if (routeDest.en.toLowerCase() === dest.en?.toLowerCase()) {
         return false;
       }
       if (routeDest.zh === dest.zh) {


### PR DESCRIPTION
We have been returning ETA remark for only single language.
See LRT Feeder: https://github.com/hkbus/hk-bus-eta/blob/285c9a9cde0a12fe8c25fbdb696d67aad8876c59/src/lrtfeeder.ts#L80-L88

Yet I followed that and started returning ETA dest for only single language since the recent commit
https://github.com/hkbus/hk-bus-eta/blob/285c9a9cde0a12fe8c25fbdb696d67aad8876c59/src/nlb.ts#L33-L37
```ts
fetchEtas({ nlbId: "1", stopId: "33", language: "zh" })
[
  {
    eta: '2025-09-25T22:00:00.000+08:00',
    remark: { zh: '預定班次', en: 'Scheduled' },
    dest: { zh: '經: 梅窩舊墟' }, // no `en`
    co: 'nlb'
  },
]

fetchEtas({ nlbId: "1", stopId: "33", language: "en" })
[
  {
    eta: '2025-09-25T22:00:00.000+08:00',
    remark: { zh: '預定班次', en: 'Scheduled' },
    dest: { en: 'Via: Mui Wo Old Town' }, // no `zh`
    co: 'nlb'
  },
]
```

Which unfortunately broke the frontend. Alternatively, this can be addressed at the hk-bus-eta repo by returning dest of the same language at the fields for both languages.

Thx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved a rare error when calculating route ETAs if a destination’s English name is missing, preventing crashes and improving stability.
  - Improved handling of incomplete destination data to ensure Time Report loads reliably without interruptions.
  - No changes to the interface or user workflows; this update enhances robustness behind the scenes for smoother ETA viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->