### PR TITLE
No JoyYou Fare for H3,H4,HK1,P960,P968 and show JoyYou Fare as $2.0 when Adult Fare is less than $10

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,7 +140,7 @@ export const getJoyYouFare = (
   if (fares === null || !fares[idx]) return "";
   const baseFare = parseFloat(fares[idx]);
   if (baseFare < 2) return fares[idx];
-  if (baseFare < 10) return `2`;
+  if (baseFare < 10) return `2.0`;
   return (Math.round(baseFare * 2) / 10).toFixed(1);
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,10 +131,10 @@ export const getJoyYouFare = (
   idx: number
 ) => {
   if (
-    (routeNo.startsWith("A") || routeNo.startsWith("NA")) &&
+    (routeNo.startsWith("A") || routeNo.startsWith("NA") || routeNo.startsWith("H") || routeNo.startsWith("P")) &&
     (co.includes("ctb") || co.includes("kmb"))
   ) {
-    // no JoyYou Fare for A- and NA- bus
+    // no JoyYou Fare for A-, NA-, H-, P- bus
     return "";
   }
   if (fares === null || !fares[idx]) return "";


### PR DESCRIPTION
additional note:
  * H1, H2 and H2K are planned not providing JoyYou Fare in 2026-2027 RPP
  * Future routes not providing JoyYou Fare are likely to follow the same prefix rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JoyYouFare exclusion logic so additional route types (those starting with H or P) are treated consistently for certain carriers, affecting which fares are included in calculations.
  * Normalized low fares display so values below 10 show a decimal format (e.g., "2.0") for consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->