### PR TITLE
Change locationSearch API domain to www.map.gov.hk from geodata.gov.hk as removed

### DIFF
--- a/src/components/route-search/AddressInput.tsx
+++ b/src/components/route-search/AddressInput.tsx
@@ -95,9 +95,9 @@ const loadAddressFromGeodata = async (
 ): Promise<Suggestion[]> => {
   if (!addr) return new Promise((resolve) => resolve([]));
 
-  // use geodata.gov.hk api, potentially add als.ogcio.gov.hk api
+  // use www.map.gov.hk api, potentially add als.ogcio.gov.hk api
   const suggestions: GeoAddrData[] = await fetch(
-    `https://geodata.gov.hk/gs/api/v1.0.0/locationSearch?q=${encodeURI(addr)}`,
+    `https://www.map.gov.hk/gs/api/v1.0.0/locationSearch?q=${encodeURI(addr)}`,
     options
   ).then((res) => res.json());
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the address suggestion lookup to use a revised remote source for fetched suggestions.
  * This change preserves existing request/response handling, parsing, coordinate projection, and suggestion mapping, so user-visible behavior and results remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->