### PR TITLE
Fix top bar layout in English

### DIFF
--- a/src/components/route-eta/ReverseButton.tsx
+++ b/src/components/route-eta/ReverseButton.tsx
@@ -128,7 +128,6 @@ const ReverseButton = ({ routeId, stopId }: ReverseButtonProps) => {
   return (
     reverseRouteUrl && (
       <>
-        <Divider orientation="vertical" sx={buttonDividerSx} />
         <Button
           variant="text"
           aria-label="open-timetable"
@@ -139,6 +138,7 @@ const ReverseButton = ({ routeId, stopId }: ReverseButtonProps) => {
         >
           {t("對頭線")}
         </Button>
+        <Divider orientation="vertical" flexItem />
       </>
     )
   );
@@ -146,18 +146,9 @@ const ReverseButton = ({ routeId, stopId }: ReverseButtonProps) => {
 
 export default ReverseButton;
 
-const buttonDividerSx: SxProps<Theme> = {
-  position: "absolute",
-  top: "0",
-  left: "calc(64px + 2%)",
-};
-
 const buttonSx: SxProps<Theme> = {
   color: (theme) =>
     theme.palette.getContrastText(theme.palette.background.default),
-  position: "absolute",
-  top: 0,
-  left: "2%",
   flexDirection: "column",
   justifyContent: "center",
   "& > .MuiButton-label": {

--- a/src/components/route-eta/RouteHeader.tsx
+++ b/src/components/route-eta/RouteHeader.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { Box, Paper, SxProps, Theme, Typography } from "@mui/material";
+import { Box, Divider, Paper, SxProps, Theme, Typography } from "@mui/material";
 import RouteNo from "../route-board/RouteNo";
 import { toProperCase } from "../../utils";
 import { useTranslation } from "react-i18next";
@@ -24,14 +24,19 @@ const RouteHeader = ({ routeId, stopId }: RouteHeaderProps) => {
 
   return (
     <Paper id="route-eta-header" sx={PaperSx} elevation={0}>
-      <RouteNo routeNo={t(route)} component="h1" align="center" />
-      <Typography component="h2" variant="caption" align="center">
-        {t("往")} {toProperCase(dest[language])}{" "}
-        {nlbId ? t("由") + " " + toProperCase(orig[language]) : ""}
-      </Typography>
       <ReverseButton routeId={routeId} stopId={stopId} />
-      <Box sx={rightBtnGroupSx}>
-        <RouteStarButton routeId={routeId} />
+      <Box sx={centerColumnSx}>
+        <Box sx={routeNoRowSx}>
+          <RouteNo routeNo={t(route)} component="h1" align="center" />
+          <RouteStarButton routeId={routeId} />
+        </Box>
+        <Typography component="h2" variant="caption" align="center">
+          {t("往")} {toProperCase(dest[language])}{" "}
+          {nlbId ? t("由") + " " + toProperCase(orig[language]) : ""}
+        </Typography>
+      </Box>
+      <Box sx={rightColumnSx}>
+        <Divider orientation="vertical" flexItem />
         <TimetableButton routeId={routeId} />
       </Box>
     </Paper>
@@ -41,13 +46,31 @@ const RouteHeader = ({ routeId, stopId }: RouteHeaderProps) => {
 export default RouteHeader;
 
 const PaperSx: SxProps<Theme> = {
+  display: "flex",
+  alignItems: "stretch",
   textAlign: "center",
   background: "transparent",
-  position: "relative",
 };
 
-const rightBtnGroupSx: SxProps<Theme> = {
-  position: "absolute",
-  top: 0,
-  right: "2%",
+const centerColumnSx: SxProps<Theme> = {
+  flex: 1,
+  position: "relative",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  minWidth: 0,
+};
+
+const routeNoRowSx: SxProps<Theme> = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "100%",
+};
+
+const rightColumnSx: SxProps<Theme> = {
+  display: "flex",
+  alignItems: "center",
+  flexShrink: 0,
 };

--- a/src/components/route-eta/RouteStarButton.tsx
+++ b/src/components/route-eta/RouteStarButton.tsx
@@ -34,6 +34,8 @@ const buttonSx: SxProps<Theme> = {
     theme.palette.getContrastText(theme.palette.background.default),
   flexDirection: "column",
   justifyContent: "center",
+  position: "absolute",
+  right: 0,
   "& > .MuiButton-label": {
     flexDirection: "column",
     justifyContent: "center",

--- a/src/components/route-eta/TimeTableButton.tsx
+++ b/src/components/route-eta/TimeTableButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button, Divider, SxProps, Theme } from "@mui/material";
+import { Button, SxProps, Theme } from "@mui/material";
 import { Schedule as ScheduleIcon } from "@mui/icons-material";
 import TimetableDrawer from "./TimetableDrawer";
 import { useTranslation } from "react-i18next";
@@ -10,7 +10,6 @@ const TimeTableButton = ({ routeId }: { routeId: string }) => {
 
   return (
     <>
-      <Divider orientation="vertical" sx={buttonDividerSx} />
       <Button
         variant="text"
         aria-label="open-timetable"
@@ -31,12 +30,6 @@ const TimeTableButton = ({ routeId }: { routeId: string }) => {
 };
 
 export default TimeTableButton;
-
-const buttonDividerSx: SxProps<Theme> = {
-  position: "absolute",
-  top: "0",
-  right: "calc(64px + 2%)",
-};
 
 const buttonSx: SxProps<Theme> = {
   color: (theme) =>


### PR DESCRIPTION
Change the top bar layout to be 3-column flex without hardcoded positions, in order to support arbitrary long text in the layout including English.

Closes #252 .

<table>
  <tr>
    <th colspan="2">Chinese (Traditional)</th>
    <th colspan="2">English</th>
  </tr>
  <tr>
    <td><b>Before</b></td>
    <td><b>After</b></td>
    <td><b>Before</b></td>
    <td><b>After</b></td>
  </tr>
  <tr>
    <td><img height="500" alt="before_zht" src="https://github.com/user-attachments/assets/adcc61ec-2059-45c9-9849-2ba5c5edefa9" /></td>
    <td><img height="500" alt="after_zht" src="https://github.com/user-attachments/assets/abc19700-4342-4bd6-9c0e-84a8c3929722" /></td>
    <td><img height="500" alt="before_eng" src="https://github.com/user-attachments/assets/d62e00bc-52a2-42fc-8979-ca0abea027fe" /></td>
    <td><img height="500" alt="after_eng" src="https://github.com/user-attachments/assets/b4d0ff99-f006-4b30-a81e-df536416ac3e" /></td>
  </tr>
</table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated route header layout organization and button positioning for improved visual structure
  * Adjusted divider placement and component alignment within the route information section

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hkbus/hk-independent-bus-eta/pull/255)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->