### PR TITLE
Fix layout (certain elements obscured by phone navigation bars in timetable & journey time; journey time stop list out of screen in mobile browsers with address bar)

### DIFF
--- a/src/components/route-eta/TimetableDrawer.tsx
+++ b/src/components/route-eta/TimetableDrawer.tsx
@@ -47,7 +47,7 @@ export default TimetableDrawer;
 const drawerSx: SxProps<Theme> = {
   width: "80%",
   maxWidth: "320px",
-  paddingTop: "56px",
+  paddingTop: "env(safe-area-inset-top)",
   paddingLeft: "20px",
   backgroundColor: (theme) => theme.palette.background.default,
   backgroundImage: "none",
@@ -61,8 +61,6 @@ const tabbarSx: SxProps<Theme> = {
     textTransform: "none",
     alignItems: "center",
     justifyContent: "center",
-    paddingTop: 0,
-    paddingBottom: 0,
     minHeight: "32px",
   },
   [`& .MuiTabs-flexContainer`]: {

--- a/src/components/route-eta/TimetableDrawer.tsx
+++ b/src/components/route-eta/TimetableDrawer.tsx
@@ -45,7 +45,6 @@ const TimetableDrawer = ({ routeId, open, onClose }: TimetableDrawerProps) => {
 export default TimetableDrawer;
 
 const drawerSx: SxProps<Theme> = {
-  height: "100vh",
   width: "80%",
   maxWidth: "320px",
   paddingTop: "56px",

--- a/src/components/route-eta/timetableDrawer/JourneyTimePanel.tsx
+++ b/src/components/route-eta/timetableDrawer/JourneyTimePanel.tsx
@@ -199,7 +199,11 @@ const JourneyTimePanel = ({ routeId }: JourneyTimePanelProps) => {
         </Typography>
       </Box>
       <Divider sx={{ my: 2 }} />
-      <Box overflow="auto" flex={1}>
+      <Box
+        overflow="auto"
+        flex={1}
+        sx={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+      >
         <Stepper orientation="vertical">
           {stops.map((stop, idx) => (
             <Step

--- a/src/components/route-eta/timetableDrawer/TimeTable.tsx
+++ b/src/components/route-eta/timetableDrawer/TimeTable.tsx
@@ -72,6 +72,7 @@ const TimeTable = ({ routeId }: TimeTableProps) => {
       </List>
       <Divider sx={{ width: "80%", my: 2 }} />
       <RouteOffiicalUrlBtn routeId={routeId} />
+      <Box sx={{ paddingBottom: "env(safe-area-inset-bottom)" }} />
     </>
   );
 };


### PR DESCRIPTION
Certain elements obscured by phone navigation bars in timetable (Before)
<img width="500" height="369" alt="image" src="https://github.com/user-attachments/assets/bec3deb2-a1c7-4827-a321-c0cd4dc0c3af" />

Journey time stop list & route official URL button out of screen in mobile browsers with address bar
Left: Before; Right: After
<img width="1000" height="1111" alt="image" src="https://github.com/user-attachments/assets/bc75059c-0ba5-4b24-a403-57f85ce47bc1" />
<img width="1000" height="1111" alt="image" src="https://github.com/user-attachments/assets/f3f289f2-f3ce-463b-8fd4-3b392a158442" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout compatibility for mobile devices with notches and display cutouts by adjusting spacing and padding to account for device-specific safe areas. Enhanced content visibility and accessibility across all device types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->