### PR TITLE
Do not request route waypoints geojson with no lookup keys

### DIFF
--- a/src/hooks/useRoutePath.tsx
+++ b/src/hooks/useRoutePath.tsx
@@ -31,31 +31,38 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
       // For light rail map
       waypointsFile = `${route}${dest.en.includes("Circular") ? "" : bound[co[0]] === "I" ? "_I" : "_O"}.json`;
     }
-    fetch(`https://hkbus.github.io/route-waypoints/${waypointsFile}`)
-      .then((r) => r.json())
-      .then((json) => {
-        setGeoJson(json);
-      })
-      .catch(() => {
-        setGeoJson({
-          features: [
-            {
-              type: "Feature",
-              geometry: {
-                type: "LineString",
-                coordinates: stops.reduce(
-                  (acc, { location: { lat, lng } }) => {
-                    acc.push([lng, lat]);
-                    return acc;
-                  },
-                  [] as [number, number][]
-                ),
-              },
+    const setFallbackGeoJson = () => {
+      setGeoJson({
+        features: [
+          {
+            type: "Feature",
+            geometry: {
+              type: "LineString",
+              coordinates: stops.reduce(
+                (acc, { location: { lat, lng } }) => {
+                  acc.push([lng, lat]);
+                  return acc;
+                },
+                [] as [number, number][]
+              ),
             },
-          ],
-          type: "FeatureCollection",
-        });
+          },
+        ],
+        type: "FeatureCollection",
       });
+    };
+    if (waypointsFile === "") {
+      setFallbackGeoJson();
+    } else {
+      fetch(`https://hkbus.github.io/route-waypoints/${waypointsFile}`)
+        .then((r) => r.json())
+        .then((json) => {
+          setGeoJson(json);
+        })
+        .catch(() => {
+          setFallbackGeoJson();
+        });
+    }
     return () => {
       setGeoJson(null);
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined waypoint loading behavior by reusing a single fallback map route when no waypoint file is provided or when loading fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->