### PR TITLE
Show the Settings 'last updated' time unambiguously (#77)

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -180,9 +180,8 @@ const Settings = () => {
               t("更新時間") +
               ": " +
               new Date(updateTime)
-                .toLocaleString()
-                .slice(0, 20)
-                .replace(",", " ")
+                .toLocaleString(undefined, { hour12: false })
+                .replace(/,\s*/, " ")
             }
           />
         </ListItemButton>


### PR DESCRIPTION
#77 points out the "last updated" time in Settings doesn't show whether it's morning or afternoon.

It's formatted with `toLocaleString().slice(0, 20)`, and the fixed 20-character cut drops the AM/PM marker on longer dates:

`12/26/2026, 3:30:00 PM` → `12/26/2026 3:30:00 ` (the "PM" gets chopped off)

Switched to 24-hour (`{ hour12: false }`) and removed the brittle slice, so the time reads unambiguously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of the “更新時間” timestamp for a more consistent, localized date and time format.
  * Adjusted spacing around the date separator so the value renders more cleanly across locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->