### PR TITLE
Route board's in-place sort flips a route's primary company (wrong-direction map)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -455,11 +455,11 @@ export const routeSortFunc = (
     return -1;
   }
 
-  // Sort by TRANSPORT_ORDER
-  const aCompany = a[1]["co"].sort(
+  // Sort by TRANSPORT_ORDER. Copy first — co is shared; in-place sort corrupts co[0].
+  const aCompany = [...a[1]["co"]].sort(
     (a, b) => transportOrder.indexOf(a) - transportOrder.indexOf(b)
   );
-  const bCompany = b[1]["co"].sort(
+  const bCompany = [...b[1]["co"]].sort(
     (a, b) => transportOrder.indexOf(a) - transportOrder.indexOf(b)
   );
 


### PR DESCRIPTION
Noticed the route map can draw the **wrong direction** — the polyline detaches from the stops — depending on the bus sort order and how you open the route.

![route 101 wrong-direction map](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/route-101-wrong-direction.png)

*Route 101 往觀塘 under 城巴優先: the route line is drawn for the opposite direction and no longer follows the stops.*

**Repro** (with 巴士排序 = 城巴優先 / CTB first):
- Open **101 往觀塘** via a direct link → the line follows the stops. ✅
- Open the same route via **搜尋 → 101 → tap it** → the same page now draws the reverse-direction line, detached from the stops. ❌

Same route, same setting — the result depends only on whether you passed through the search list first.

**Cause:** `routeSortFunc` sorts each route's `co` array in place, and that array is a reference into the shared `routeList`. So rendering the route board flips `co[0]` (the primary company) on shared data. `useRoutePath` then picks the waypoints file by `bound[co[0]]`, which on a jointly-operated route (e.g. 101, where `bound.kmb="I"` but `bound.ctb="O"`) is the opposite direction.

**Fix:** copy `co` before sorting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route ordering to avoid unintentionally changing the original stop data during sorting.
  * This helps keep displayed route information consistent and prevents side effects when comparing transport options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->