### PR TITLE
Don't log user location and opened URLs to the console

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -372,7 +372,6 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
           navigator.geolocation.getCurrentPosition(
             ({ coords: { latitude, longitude } }) => {
               updateGeolocation({ lat: latitude, lng: longitude });
-              console.log(latitude, longitude);
               setGeoPermission("granted");
             },
             (err) => console.error("Fresh fix failed", err),
@@ -644,7 +643,6 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
         harmonyBridger.openUrl(url);
       }
     } else {
-      console.log(url);
       window.open(url, "_blank");
     }
   }, []);


### PR DESCRIPTION
Two leftover debug `console.log` calls print user data to the browser console:

- the resolved GPS coordinates (in the geolocation success handler)
- every URL opened via `openUrl`

Removing both. `console.error` is already used for the actual error cases, so nothing useful is lost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary console logging from location permission handling and link-opening behavior for a cleaner runtime experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->