### PR TITLE
Don't re-arm the geolocation watch while the page is hidden

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -305,7 +305,8 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
         geoWatcherId.current = null;
       }
 
-      if (geoPermission === "granted") {
+      // Don't re-arm the watch while hidden — keeps GPS off in the background.
+      if (geoPermission === "granted" && !document.hidden) {
         try {
           if (window.iOSRNWebView === true) return;
           navigator.geolocation.getCurrentPosition(


### PR DESCRIPTION
**TL;DR:** Backgrounding the app **restarts** high-accuracy GPS instead of stopping it — a battery drain fixed by a one-line guard.

`onVisibilityChange` clears the geolocation watch, then re-arms a fresh `watchPosition({ enableHighAccuracy: true })` whenever permission is granted — it never checks `document.hidden`. So hiding the tab re-creates the watch instead of leaving it off.

Guarding the (re)start with `!document.hidden` stops GPS while hidden and resumes it when the page is visible again. Verified below — happy to adjust.

<details><summary><b>Repro — buggy vs fixed handler (only the guarded line differs)</b></summary>

Faithful extraction of `onVisibilityChange`, counting `watchPosition` calls across mount → hide → show:

```
BUGGY (master): mount watch=1  ->  hide watch=2  ->  show watch=3
FIXED (patch):  mount watch=1  ->  hide watch=1  ->  show watch=2
```
On **hide**, master re-arms the watch (1→2) while hidden; the patch leaves it off (1→1) and resumes on show. (A real-app browser test was inconclusive — the live deploy runs older geolocation code — so this runs the exact current-master handler logic.)
</details>

<details><summary><b>Why this is the app's responsibility, not the browser's</b></summary>

- **MDN — Page Visibility API:** the API is "useful for saving resources… by letting a page avoid performing unnecessary tasks when the document isn't visible," and lists **data polling** among the things to stop when hidden. <https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API>
- **Mozilla bug 1254911** (exactly this): *"no reason to keep GPS active (especially on mobile where it drains A LOT of battery) when the app is in background."* Chrome/Safari suspend background geolocation, but **Firefox did not** and on desktop it was **WONTFIX** — so an app can't rely on the browser to stop it. <https://bugzilla.mozilla.org/show_bug.cgi?id=1254911>
- hkbus also ships as a Tauri / RN webview shell, where a backgrounded page's GPS isn't suspended at all — so the drain is real there regardless of browser.

**Honest caveat:** on Chrome/Safari the browser may already throttle the backgrounded watch, so there the re-arm is partly a no-op; the clear wins are Firefox + the native shells, plus dropping the tear-down/re-create churn on every visibility toggle.
</details>

<details><summary><b>Review + gates</b></summary>

- **Codex** (independent, prompted to refute) traced mount(visible)→arm, hide→clear+skip, show→resume: found no state where a visible+granted page ends up with no watch; `state.isVisible` still set unconditionally; effect cleanup compatible; first-mount-while-hidden correctly defers to the visible transition; no SSR concern (`document.hidden` read inside `useEffect`).
- `tsc --noEmit` exit 0 · `eslint --max-warnings 0` clean.
</details>

@coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location tracking behavior when switching away from and back to the app.
  * The app now avoids restarting GPS monitoring while the page is hidden, helping prevent unnecessary background activity and more reliable tracking on return.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->