### PR TITLE
Landscape / wide-screen layout: home route-list grid + route-detail split (proposal for #196)

### DIFF
--- a/src/components/home/lists/HomeRouteListDropDown.tsx
+++ b/src/components/home/lists/HomeRouteListDropDown.tsx
@@ -39,11 +39,8 @@ const HomeRouteListDropDown = ({
           {routes.map(
             (selectedRoute, idx) =>
               Boolean(selectedRoute) && (
-                // POC (#196 landscape): wrap each row so the row's ListItem +
-                // its trailing Divider stay together as ONE grid cell. Without
-                // the wrapper the Divider (a sibling emitted by
-                // SuccinctTimeReport) would take its own grid cell and break
-                // the columns. SuccinctTimeReport itself is untouched.
+                // #196: wrap each row so its ListItem + trailing Divider stay
+                // one grid cell (else the Divider takes its own cell on md).
                 <Box key={`route-${name}-${idx}`}>
                   <SuccinctTimeReport routeId={selectedRoute} />
                 </Box>
@@ -66,9 +63,7 @@ const headerSx: SxProps<Theme> = {
   cursor: "pointer",
 };
 
-// POC (#196 landscape): on wide screens lay the rows out in a responsive grid
-// of 2-3 auto-fitted columns. Below `md` no `display: grid` is emitted, so the
-// rows stack in a single column exactly as before (mobile is untouched).
+// #196: responsive multi-column grid on md+; single column (unchanged) below md.
 const listSx: SxProps<Theme> = {
   display: { md: "grid" },
   gridTemplateColumns: {

--- a/src/components/home/lists/HomeRouteListDropDown.tsx
+++ b/src/components/home/lists/HomeRouteListDropDown.tsx
@@ -35,14 +35,18 @@ const HomeRouteListDropDown = ({
       </Box>
       <Divider />
       {expaned && (
-        <List disablePadding>
+        <List disablePadding sx={listSx}>
           {routes.map(
             (selectedRoute, idx) =>
               Boolean(selectedRoute) && (
-                <SuccinctTimeReport
-                  key={`route-${name}-${idx}`}
-                  routeId={selectedRoute}
-                />
+                // POC (#196 landscape): wrap each row so the row's ListItem +
+                // its trailing Divider stay together as ONE grid cell. Without
+                // the wrapper the Divider (a sibling emitted by
+                // SuccinctTimeReport) would take its own grid cell and break
+                // the columns. SuccinctTimeReport itself is untouched.
+                <Box key={`route-${name}-${idx}`}>
+                  <SuccinctTimeReport routeId={selectedRoute} />
+                </Box>
               )
           )}
         </List>
@@ -60,4 +64,15 @@ const headerSx: SxProps<Theme> = {
   justifyContent: "space-between",
   mx: 1,
   cursor: "pointer",
+};
+
+// POC (#196 landscape): on wide screens lay the rows out in a responsive grid
+// of 2-3 auto-fitted columns. Below `md` no `display: grid` is emitted, so the
+// rows stack in a single column exactly as before (mobile is untouched).
+const listSx: SxProps<Theme> = {
+  display: { md: "grid" },
+  gridTemplateColumns: {
+    md: "repeat(auto-fill, minmax(340px, 1fr))",
+  },
+  columnGap: { md: 1 },
 };

--- a/src/components/home/lists/HomeRouteListDropDown.tsx
+++ b/src/components/home/lists/HomeRouteListDropDown.tsx
@@ -39,9 +39,15 @@ const HomeRouteListDropDown = ({
           {routes.map(
             (selectedRoute, idx) =>
               Boolean(selectedRoute) && (
-                // #196: wrap each row so its ListItem + trailing Divider stay
-                // one grid cell (else the Divider takes its own cell on md).
-                <Box key={`route-${name}-${idx}`}>
+                // #196: on md wrap each row so its ListItem + trailing Divider
+                // stay one grid cell (else the Divider takes its own cell).
+                // `display:contents` below md → the wrapper generates no box, so
+                // mobile layout/rendering is unchanged (the ListItem lays out as
+                // a direct child of the <ul>, as before).
+                <Box
+                  key={`route-${name}-${idx}`}
+                  sx={{ display: { xs: "contents", md: "block" } }}
+                >
                   <SuccinctTimeReport routeId={selectedRoute} />
                 </Box>
               )

--- a/src/components/layout/Root.tsx
+++ b/src/components/layout/Root.tsx
@@ -55,9 +55,7 @@ const rootSx: SxProps<Theme> = {
   flexDirection: "column",
   justifyContent: "space-between",
   height: "100%",
-  // POC (#196 landscape): let the app use more horizontal width on wide
-  // screens. Below `md` this rule is not emitted, so the container keeps its
-  // original `maxWidth="xs"` (444px) and mobile is pixel-identical.
+  // #196: widen on md+; below md keeps the original maxWidth="xs" (mobile unchanged).
   maxWidth: { md: "min(1200px, 100%)" },
 };
 

--- a/src/components/layout/Root.tsx
+++ b/src/components/layout/Root.tsx
@@ -55,6 +55,10 @@ const rootSx: SxProps<Theme> = {
   flexDirection: "column",
   justifyContent: "space-between",
   height: "100%",
+  // POC (#196 landscape): let the app use more horizontal width on wide
+  // screens. Below `md` this rule is not emitted, so the container keeps its
+  // original `maxWidth="xs"` (444px) and mobile is pixel-identical.
+  maxWidth: { md: "min(1200px, 100%)" },
 };
 
 // Visually hidden until it receives keyboard focus, then shown on top so

--- a/src/components/map/maplibre/RouteMap.tsx
+++ b/src/components/map/maplibre/RouteMap.tsx
@@ -198,7 +198,14 @@ const RouteMap = ({
         // `cooperativeGestures` instead.
         onDragStart={handleDragStartOrEnd}
         onDragEnd={handleDragStartOrEnd}
-        style={{ height: "35vh" }}
+        // POC(#196 landscape): the map now always fills 100% of its container
+        // (the `rootSx` Box below), and that Box is what carries the responsive
+        // height — 35vh on mobile, 100% (fills the right pane) at md+. Height
+        // must live on the container rather than here, because BaseMap always
+        // sets an inline height on the maplibre element that would otherwise
+        // win over any responsive CSS. On mobile this is still 35vh (100% of a
+        // 35vh Box), so it is pixel-identical to before.
+        style={{ height: "100%" }}
       >
         <MapEffects pending={pendingNav} onApplied={handleNavApplied} />
 
@@ -389,13 +396,15 @@ const classes = {
 // `<Marker>` mounts its children inside the map container, which is
 // itself inside this Box.
 const rootSx: SxProps<Theme> = {
-  height: "35vh",
+  // POC(#196 landscape): 35vh on mobile (unchanged), 100% at md+ so the map
+  // fills the right pane of the two-pane split. This Box is the single source
+  // of truth for the map's height (see the BaseMap `style` note above).
+  height: { xs: "35vh", md: "100%" },
   filter: (theme) =>
     theme.palette.mode === "dark" ? "brightness(0.8)" : "none",
-  // Two layers of explicit 35vh (on the Box and on the inner map
-  // container) keeps the map sized correctly even under flex parents.
+  // Inner map container follows the Box: 35vh on mobile, 100% at md+.
   "& .maplibregl-map": {
-    height: "35vh",
+    height: { xs: "35vh", md: "100%" },
   },
   [`& .${classes.mtrMarker}`]: {
     backgroundImage: `url(/img/mtr.svg)`,

--- a/src/components/map/maplibre/RouteMap.tsx
+++ b/src/components/map/maplibre/RouteMap.tsx
@@ -198,13 +198,8 @@ const RouteMap = ({
         // `cooperativeGestures` instead.
         onDragStart={handleDragStartOrEnd}
         onDragEnd={handleDragStartOrEnd}
-        // POC(#196 landscape): the map now always fills 100% of its container
-        // (the `rootSx` Box below), and that Box is what carries the responsive
-        // height — 35vh on mobile, 100% (fills the right pane) at md+. Height
-        // must live on the container rather than here, because BaseMap always
-        // sets an inline height on the maplibre element that would otherwise
-        // win over any responsive CSS. On mobile this is still 35vh (100% of a
-        // 35vh Box), so it is pixel-identical to before.
+        // #196: fill the container; responsive height lives on the rootSx Box
+        // below (BaseMap's inline height would override any responsive CSS here).
         style={{ height: "100%" }}
       >
         <MapEffects pending={pendingNav} onApplied={handleNavApplied} />
@@ -396,13 +391,10 @@ const classes = {
 // `<Marker>` mounts its children inside the map container, which is
 // itself inside this Box.
 const rootSx: SxProps<Theme> = {
-  // POC(#196 landscape): 35vh on mobile (unchanged), 100% at md+ so the map
-  // fills the right pane of the two-pane split. This Box is the single source
-  // of truth for the map's height (see the BaseMap `style` note above).
+  // #196: 35vh on mobile (unchanged), 100% at md+ to fill the right pane.
   height: { xs: "35vh", md: "100%" },
   filter: (theme) =>
     theme.palette.mode === "dark" ? "brightness(0.8)" : "none",
-  // Inner map container follows the Box: 35vh on mobile, 100% at md+.
   "& .maplibregl-map": {
     height: { xs: "35vh", md: "100%" },
   },

--- a/src/components/route-eta/StopAccordionList.tsx
+++ b/src/components/route-eta/StopAccordionList.tsx
@@ -78,7 +78,8 @@ const StopAccordions = ({
 export default StopAccordions;
 
 const rootSx: SxProps<Theme> = {
-  // #196: mobile scrolls here; on md the list-pane wrapper is the single
-  // scroller, so don't reserve a second (dead) scrollbar gutter at the split.
-  overflowY: { xs: "scroll", md: "visible" },
+  // #196: `auto` (not the always-on `scroll`) so this doesn't reserve a second,
+  // dead scrollbar gutter next to the list pane's own scroller on md. Still
+  // self-scrolls when it IS the scroller (mobile, or md without a map).
+  overflowY: { xs: "scroll", md: "auto" },
 };

--- a/src/components/route-eta/StopAccordionList.tsx
+++ b/src/components/route-eta/StopAccordionList.tsx
@@ -78,5 +78,7 @@ const StopAccordions = ({
 export default StopAccordions;
 
 const rootSx: SxProps<Theme> = {
-  overflowY: "scroll",
+  // #196: mobile scrolls here; on md the list-pane wrapper is the single
+  // scroller, so don't reserve a second (dead) scrollbar gutter at the split.
+  overflowY: { xs: "scroll", md: "visible" },
 };

--- a/src/pages/RouteEtaPage.tsx
+++ b/src/pages/RouteEtaPage.tsx
@@ -229,16 +229,30 @@ const RouteEta = () => {
     routeListEntry,
   ]);
 
+  const showMap = !energyMode && navigator.userAgent !== "prerendering";
+  const stopListEl = (
+    <StopAccordionList
+      routeId={routeId}
+      stopIdx={stopIdx}
+      routeListEntry={routeListEntry}
+      stopIds={stopIds}
+      handleChange={handleChange}
+      onStopInfo={handleStopInfo}
+    />
+  );
+
   return (
     <>
       <input hidden id="render" />
       <RouteHeader routeId={routeId} stopId={stopIds[stopIdx]} />
       <RouteUpdateNotice route={routeListEntry} />
       {/* #196: two-pane split (list-left / map-right) on md+; below md every box
-          is display:contents, so map+list stack as before (mobile unchanged). */}
-      <Box sx={landscapeSplitSx}>
-        <Box sx={mapPaneSx}>
-          {!energyMode && navigator.userAgent !== "prerendering" && (
+          is display:contents, so map+list stack as before (mobile unchanged).
+          Without a map (energyMode / prerender) we skip the split and render the
+          list full-width, exactly as before — no empty pane. */}
+      {showMap ? (
+        <Box sx={landscapeSplitSx}>
+          <Box sx={mapPaneSx}>
             <Suspense fallback={null}>
               <RouteMap
                 routeId={routeId}
@@ -249,19 +263,12 @@ const RouteEta = () => {
                 onMarkerClick={onMarkerClick}
               />
             </Suspense>
-          )}
+          </Box>
+          <Box sx={listPaneSx}>{stopListEl}</Box>
         </Box>
-        <Box sx={listPaneSx}>
-          <StopAccordionList
-            routeId={routeId}
-            stopIdx={stopIdx}
-            routeListEntry={routeListEntry}
-            stopIds={stopIds}
-            handleChange={handleChange}
-            onStopInfo={handleStopInfo}
-          />
-        </Box>
-      </Box>
+      ) : (
+        stopListEl
+      )}
       <StopDialog
         open={isDialogOpen}
         stops={dialogStop}

--- a/src/pages/RouteEtaPage.tsx
+++ b/src/pages/RouteEtaPage.tsx
@@ -287,12 +287,14 @@ const mapPaneSx: SxProps<Theme> = {
   minWidth: { md: 0 },
 };
 
-// List pane — left, ~42%, scrolls independently.
+// List pane — left, ~42%, scrolls independently. `background.paper` so the
+// scrollbar's transparent track reveals the list surface, not the yellow page bg.
 const listPaneSx: SxProps<Theme> = {
   display: { xs: "contents", md: "block" },
   flex: { md: "0 0 42%" },
   height: { md: "100%" },
   overflowY: { md: "auto" },
+  bgcolor: { md: "background.paper" },
 };
 
 const getRouteEntry = (id: string, routeList: RouteList) => {

--- a/src/pages/RouteEtaPage.tsx
+++ b/src/pages/RouteEtaPage.tsx
@@ -234,16 +234,8 @@ const RouteEta = () => {
       <input hidden id="render" />
       <RouteHeader routeId={routeId} stopId={stopIds[stopIdx]} />
       <RouteUpdateNotice route={routeListEntry} />
-      {/*
-        POC(#196 landscape): two-pane split on md+ (≥900px) ONLY — stop list
-        left (~42%, scrolls independently), map right (~58%, fills height).
-        Below md every box here is `display: contents`, so the wrapper and the
-        two column boxes generate no box at all: the map + list fall back to
-        being direct children of <main> and stack vertically EXACTLY as before
-        (mobile is pixel-identical). The map box is DOM-first so that on mobile
-        (contents) it stays ABOVE the list; at md the row is `row-reverse`,
-        which places the map on the RIGHT and the list on the LEFT.
-      */}
+      {/* #196: two-pane split (list-left / map-right) on md+; below md every box
+          is display:contents, so map+list stack as before (mobile unchanged). */}
       <Box sx={landscapeSplitSx}>
         <Box sx={mapPaneSx}>
           {!energyMode && navigator.userAgent !== "prerendering" && (
@@ -279,19 +271,15 @@ const RouteEta = () => {
   );
 };
 
-// POC(#196 landscape) — all rules md-gated; below md they collapse to
-// `display: contents` so the layout is identical to the plain vertical stack.
+// #196: md-gated; below md all collapse to display:contents → identical to the vertical stack.
 const landscapeSplitSx: SxProps<Theme> = {
   display: { xs: "contents", md: "flex" },
-  // row-reverse: map (DOM-first) → right pane; list (DOM-second) → left pane.
-  flexDirection: { md: "row-reverse" },
-  // Fill the remaining height of <main> (which is flex:1 + overflow:hidden),
-  // so the two panes get a bounded height to scroll/fill within.
-  flex: { md: 1 },
+  flexDirection: { md: "row-reverse" }, // map (DOM-first) → right, list → left
+  flex: { md: 1 }, // fill remaining <main> height so panes have a bounded height
   minHeight: { md: 0 },
 };
 
-// Map pane — right side, ~58%. Stretches to the row height; RouteMap fills it.
+// Map pane — right, ~58%; RouteMap fills it.
 const mapPaneSx: SxProps<Theme> = {
   display: { xs: "contents", md: "block" },
   flex: { md: 1 },
@@ -299,7 +287,7 @@ const mapPaneSx: SxProps<Theme> = {
   minWidth: { md: 0 },
 };
 
-// List pane — left side, ~42%, scrolls independently in a fixed-height column.
+// List pane — left, ~42%, scrolls independently.
 const listPaneSx: SxProps<Theme> = {
   display: { xs: "contents", md: "block" },
   flex: { md: "0 0 42%" },

--- a/src/pages/RouteEtaPage.tsx
+++ b/src/pages/RouteEtaPage.tsx
@@ -7,6 +7,7 @@ import React, {
   Suspense,
 } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import { Box, type SxProps, type Theme } from "@mui/material";
 import RouteHeader from "../components/route-eta/RouteHeader";
 import StopAccordionList from "../components/route-eta/StopAccordionList";
 import StopDialog from "../components/route-eta/StopDialog";
@@ -233,26 +234,42 @@ const RouteEta = () => {
       <input hidden id="render" />
       <RouteHeader routeId={routeId} stopId={stopIds[stopIdx]} />
       <RouteUpdateNotice route={routeListEntry} />
-      {!energyMode && navigator.userAgent !== "prerendering" && (
-        <Suspense fallback={null}>
-          <RouteMap
+      {/*
+        POC(#196 landscape): two-pane split on md+ (≥900px) ONLY — stop list
+        left (~42%, scrolls independently), map right (~58%, fills height).
+        Below md every box here is `display: contents`, so the wrapper and the
+        two column boxes generate no box at all: the map + list fall back to
+        being direct children of <main> and stack vertically EXACTLY as before
+        (mobile is pixel-identical). The map box is DOM-first so that on mobile
+        (contents) it stays ABOVE the list; at md the row is `row-reverse`,
+        which places the map on the RIGHT and the list on the LEFT.
+      */}
+      <Box sx={landscapeSplitSx}>
+        <Box sx={mapPaneSx}>
+          {!energyMode && navigator.userAgent !== "prerendering" && (
+            <Suspense fallback={null}>
+              <RouteMap
+                routeId={routeId}
+                stopIds={stopIds}
+                stopIdx={stopIdx}
+                route={route}
+                companies={co}
+                onMarkerClick={onMarkerClick}
+              />
+            </Suspense>
+          )}
+        </Box>
+        <Box sx={listPaneSx}>
+          <StopAccordionList
             routeId={routeId}
-            stopIds={stopIds}
             stopIdx={stopIdx}
-            route={route}
-            companies={co}
-            onMarkerClick={onMarkerClick}
+            routeListEntry={routeListEntry}
+            stopIds={stopIds}
+            handleChange={handleChange}
+            onStopInfo={handleStopInfo}
           />
-        </Suspense>
-      )}
-      <StopAccordionList
-        routeId={routeId}
-        stopIdx={stopIdx}
-        routeListEntry={routeListEntry}
-        stopIds={stopIds}
-        handleChange={handleChange}
-        onStopInfo={handleStopInfo}
-      />
+        </Box>
+      </Box>
       <StopDialog
         open={isDialogOpen}
         stops={dialogStop}
@@ -260,6 +277,34 @@ const RouteEta = () => {
       />
     </>
   );
+};
+
+// POC(#196 landscape) — all rules md-gated; below md they collapse to
+// `display: contents` so the layout is identical to the plain vertical stack.
+const landscapeSplitSx: SxProps<Theme> = {
+  display: { xs: "contents", md: "flex" },
+  // row-reverse: map (DOM-first) → right pane; list (DOM-second) → left pane.
+  flexDirection: { md: "row-reverse" },
+  // Fill the remaining height of <main> (which is flex:1 + overflow:hidden),
+  // so the two panes get a bounded height to scroll/fill within.
+  flex: { md: 1 },
+  minHeight: { md: 0 },
+};
+
+// Map pane — right side, ~58%. Stretches to the row height; RouteMap fills it.
+const mapPaneSx: SxProps<Theme> = {
+  display: { xs: "contents", md: "block" },
+  flex: { md: 1 },
+  height: { md: "100%" },
+  minWidth: { md: 0 },
+};
+
+// List pane — left side, ~42%, scrolls independently in a fixed-height column.
+const listPaneSx: SxProps<Theme> = {
+  display: { xs: "contents", md: "block" },
+  flex: { md: "0 0 42%" },
+  height: { md: "100%" },
+  overflowY: { md: "auto" },
 };
 
 const getRouteEntry = (id: string, routeList: RouteList) => {


### PR DESCRIPTION
Landscape / wide-screen support (proposal for #196, draft): grid the home route-lists into columns, and split route-detail into list-left / map-right.

Gated behind MUI `md` (≥900px) via `display:{xs:"contents",md:...}` — below `md` no wrapper box is generated, so mobile renders exactly as today.

![landscape grid](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/landscape-grid.png)

Verified in a real browser at multiple widths: one scroll container, no empty map pane under energyMode, mobile layout unchanged. Settings/search width still needs a follow-up cap.
