### PR TITLE
Suppress native keyboard on header search via inputmode="none"

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -174,6 +174,7 @@ const Header = () => {
         id="searchInput"
         sx={searchRouteInputSx}
         type="text"
+        inputProps={{ inputMode: "none" }}
         ref={inputRef}
         value={searchRoute}
         placeholder={t("路線")}


### PR DESCRIPTION
Adds `inputmode="none"` to the header search field, so browsers never offer a native keyboard for an input that's driven entirely by the app's own on-screen keypad (`RouteInputPad` on `/board`).

- Today: suppressed reactively — `onFocus` calls `blur()` when `checkMobile()` is true, racing `onClick={handleInputClick}`
- Per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/inputmode): `inputmode="none"` is exactly for "the page implements its own keyboard input control" — static, browser-honored, no race
- Existing handlers untouched — kept as fallback for browsers that don't honor `inputmode`

Verified:
- `tsc` / `vite build` / `prettier` — clean
- Playwright: attribute present on `/` and `/board`; click still navigates to `/board`; typing + custom keypad still work
- Codex adversarial review: no blockers (`inputProps` merges cleanly under MUI 5.15.11 `InputBase`; nothing else reads `inputMode`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the search field’s behavior on devices and browsers by preventing the keyboard/input method from appearing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->