### PR TITLE
Declutter the route stop list to one line per stop

### DIFF
--- a/src/components/route-eta/StopAccordion.tsx
+++ b/src/components/route-eta/StopAccordion.tsx
@@ -111,6 +111,14 @@ const StopAccordion = React.forwardRef<HTMLDivElement, StopAccordionProps>(
       [idx, onSummaryClick]
     );
 
+    // Fares can differ per stop (section fares), so keep every value — just
+    // present them compactly and surface the holiday fare only when it
+    // actually differs from the regular one.
+    const regularFare = fares && fares[idx] ? fares[idx] : "";
+    const holidayFare =
+      faresHoliday && faresHoliday[idx] ? faresHoliday[idx] : "";
+    const showHolidayFare = holidayFare !== "" && holidayFare !== regularFare;
+
     return (
       <Accordion
         id={`stop-${idx}`}
@@ -121,16 +129,16 @@ const StopAccordion = React.forwardRef<HTMLDivElement, StopAccordionProps>(
         sx={accordionSx}
       >
         <AccordionSummary sx={accordionSummarySx}>
-          <Typography component="h3" variant="body1" sx={{ fontWeight: 700 }}>
+          <Typography component="h3" variant="body1" sx={stopNameSx}>
             {idx + 1}. {toProperCase(stop.name[language])}
           </Typography>
-          <Typography variant="body2">
-            {fares && fares[idx] ? t("車費") + ": $" + fares[idx] : ""}
-            {faresHoliday && faresHoliday[idx]
-              ? "　　" + t("假日車費") + ": $" + faresHoliday[idx]
-              : ""}
-            {joyYouFare ? "　　" + t("樂悠車費") + `: $${joyYouFare}` : ""}
-          </Typography>
+          {(regularFare || showHolidayFare || joyYouFare) && (
+            <Typography variant="body2" sx={fareSx}>
+              {regularFare && `$${regularFare}`}
+              {showHolidayFare && ` ${t("假日")} $${holidayFare}`}
+              {joyYouFare && ` ${t("樂悠")} $${joyYouFare}`}
+            </Typography>
+          )}
         </AccordionSummary>
         <AccordionDetails sx={accordionDetailsRootSx}>
           <TimeReport
@@ -229,16 +237,32 @@ const accordionSummarySx: SxProps<Theme> = {
       : "rgba(0, 0, 0, .03)",
   "&.Mui-expanded": {
     borderBottom: "1px solid rgba(0, 0, 0, .125)",
-    minHeight: 44,
+    minHeight: 60,
   },
-  minHeight: 44,
+  // Keep the previous 60px height even though the content is now one line —
+  // a smaller row would be harder for elderly users to tap.
+  minHeight: 60,
   "& .MuiAccordionSummary-content": {
     margin: "8px 0",
-    flexDirection: "column",
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 1,
     "&.Mui-expanded": {
       margin: "8px 0",
     },
   },
+};
+
+const stopNameSx: SxProps<Theme> = {
+  fontWeight: 700,
+  flex: 1,
+  minWidth: 0,
+};
+
+const fareSx: SxProps<Theme> = {
+  flexShrink: 0,
+  whiteSpace: "nowrap",
+  color: (theme) => theme.palette.text.secondary,
 };
 
 const accordionDetailsRootSx: SxProps<Theme> = {

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -69,6 +69,8 @@ const resources = {
       車費: "Fare",
       假日車費: "Holiday fare",
       樂悠車費: "JoyYou fare",
+      假日: "Holiday",
+      樂悠: "JoyYou",
       特別班: "SP.",
       "home-page-description":
         "Ad-free mobile application for checking bus routes, stops, estimated time of arrival(ETA) of Kowloon Motor Bus Co. (KMB), Long Win Bus (LWB), CityBus (CTB), New Lantao Bus (NLB) and Green Minibus (GMB) - HK Bus ETA App",


### PR DESCRIPTION
> Draft / RFC — sharing the direction early for your thoughts before polishing further.

**TL;DR** — Each stop rendered a second line repeating the fare with full word-labels (`車費: $5.8　　樂悠車費: $2.0`) — the same string on many rows, halving how many stops fit on small screens. Now one line: name left, compact fare right. **Every per-stop fare is kept** (section fares differ per stop); only the repeated labels go.

![before / after](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/declutter-stop-list.png)

<details><summary>Section fares are preserved — no data loss</summary>

- `regularFare` (`fares[idx]`) is rendered for **every** stop, right-aligned with `flexShrink:0; whiteSpace:nowrap` so it never truncates.
- The holiday fare shows only when it **differs** from the regular one — when equal it was pure repetition, so no data is lost; when it differs it is still shown.
- Tap target held at 60px (the old two-line rendered height) so rows are no smaller to tap.
- Compact labels go through i18n keys (`假日`/`樂悠`), not hardcoded strings.
- `tsc` clean; no dependency changes.
</details>
