### PR TITLE
Show travel direction with arrows along the route line

### DIFF
--- a/src/components/map/maplibre/RouteMap.tsx
+++ b/src/components/map/maplibre/RouteMap.tsx
@@ -231,6 +231,20 @@ const RouteMap = ({
               }}
               layout={{ "line-cap": "round", "line-join": "round" }}
             />
+            {/* Arrowheads along the path show the travel direction — so a
+                rider knows which side of the road to wait on. */}
+            <Layer
+              id="route-path-arrows"
+              type="symbol"
+              layout={{
+                "symbol-placement": "line",
+                "symbol-spacing": 70,
+                "icon-image": "route-arrow",
+                "icon-rotation-alignment": "map",
+                "icon-allow-overlap": true,
+                "icon-ignore-placement": true,
+              }}
+            />
           </Source>
         ) : null}
 
@@ -298,7 +312,50 @@ const MapEffects = ({
     else m.flyTo(pending.center);
     onApplied();
   }, [pending, onApplied, m]);
+
+  // Register the direction-arrow image via `styleimagemissing` so it survives
+  // light/dark restyles (which clear registered images) with no icon fetch.
+  useEffect(() => {
+    const map = m.getRawMap();
+    if (!map) return;
+    const ensure = (id?: string) => {
+      if (id && id !== ROUTE_ARROW_ID) return;
+      if (!map.hasImage(ROUTE_ARROW_ID)) {
+        map.addImage(ROUTE_ARROW_ID, makeRouteArrow(), { pixelRatio: 2 });
+      }
+    };
+    const onMissing = (e: { id: string }) => ensure(e.id);
+    map.on("styleimagemissing", onMissing);
+    ensure();
+    return () => {
+      map.off("styleimagemissing", onMissing);
+    };
+  }, [m]);
   return null;
+};
+
+const ROUTE_ARROW_ID = "route-arrow";
+
+const makeRouteArrow = (): ImageData => {
+  const s = 24; // source px; added at pixelRatio 2 → ~12px on screen
+  const cvs = document.createElement("canvas");
+  cvs.width = s;
+  cvs.height = s;
+  const ctx = cvs.getContext("2d");
+  if (!ctx) return new ImageData(s, s);
+  // Triangle pointing right (+x); the line layer rotates it to the path.
+  ctx.beginPath();
+  ctx.moveTo(s * 0.28, s * 0.18);
+  ctx.lineTo(s * 0.82, s * 0.5);
+  ctx.lineTo(s * 0.28, s * 0.82);
+  ctx.closePath();
+  ctx.fillStyle = "#ffffff";
+  ctx.strokeStyle = "rgba(0, 0, 0, 0.55)";
+  ctx.lineWidth = s * 0.09;
+  ctx.lineJoin = "round";
+  ctx.fill();
+  ctx.stroke();
+  return ctx.getImageData(0, 0, s, s);
 };
 
 interface StopMarkerInfo {


### PR DESCRIPTION
**TL;DR** — The route line had no direction cue, so it wasn't obvious which way the bus runs — i.e. which side of the road to wait on. Arrowheads along the line now point in the travel direction.

![direction arrows](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/route-direction-arrows.png)

Arrows follow the path's coordinate order, verified origin→destination: the fallback path is built from the stops in sequence, and the arrows flip when the route direction is reversed (對頭線). The per-bound `route-waypoints/{gtfsId}-{I,O}.json` are stored in travel order.

<details><summary>Implementation / perf — and why a custom icon</summary>

- maplibre symbol layer (`symbol-placement: line`) with the arrow drawn to a canvas and registered via `styleimagemissing` — no external icon/font fetch, and it survives the light/dark restyle (which clears registered images). Registration folded into the existing `MapEffects`.
- The style's sprite ships an `arrow`, but it's **non-SDF** (fixed light-grey), so it can't be recoloured and washes out on the lighter line colours (CTB yellow / GMB green / MTR-bus blue) — the line colour varies per operator, so a white-with-dark-outline custom icon is what contrasts on all of them.
- `icon-ignore-placement` + `icon-allow-overlap` skip the collision pass → cheap on old devices. One-time 24×24 canvas, no per-frame cost.
- `tsc` clean; no dependency changes.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added directional arrowheads along route lines on the map, making route direction easier to follow.
  * Route arrows now stay aligned with the path and repeat at regular intervals for better visibility.

* **Bug Fixes**
  * Improved map rendering so route arrows are restored automatically after style changes.
  * Ensured the arrow icon is initialized on load to reduce missing-symbol issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->