### PR TITLE
Small visual polish — tap feedback, operator colours, tab-bar fade

### DIFF
--- a/src/components/CompanyColorDot.tsx
+++ b/src/components/CompanyColorDot.tsx
@@ -1,0 +1,32 @@
+import { Box } from "@mui/material";
+import { Company } from "hk-bus-eta";
+import { getLineColor } from "../utils";
+
+interface CompanyColorDotProps {
+  companies: Company[];
+  route: string;
+}
+
+// A small swatch in the operator's line colour (KMB red, CTB yellow, GMB green,
+// …) so companies are distinguishable at a glance. Reuses getLineColor — the
+// same mapping the route map already uses — and carries a faint outline so pale
+// colours (e.g. CTB yellow) stay visible on the white list background.
+const CompanyColorDot = ({ companies, route }: CompanyColorDotProps) => (
+  <Box
+    component="span"
+    aria-hidden="true"
+    sx={{
+      display: "inline-block",
+      verticalAlign: "middle",
+      flexShrink: 0,
+      width: 8,
+      height: 8,
+      marginRight: 0.5,
+      borderRadius: "50%",
+      backgroundColor: getLineColor(companies, route),
+      border: "1px solid rgba(0, 0, 0, 0.2)",
+    }}
+  />
+);
+
+export default CompanyColorDot;

--- a/src/components/home/HomeTabbar.tsx
+++ b/src/components/home/HomeTabbar.tsx
@@ -26,8 +26,7 @@ const HomeTabbar = ({ homeTab, onChangeTab }: HomeTabbarProps) => {
       onChange={(_, v) => onChangeTab(v, true)}
       sx={tabbarSx}
       variant="scrollable"
-      scrollButtons
-      allowScrollButtonsMobile
+      scrollButtons={false}
     >
       <Tab
         iconPosition="start"
@@ -84,6 +83,10 @@ export const isHomeTab = (
 const tabbarSx: SxProps<Theme> = {
   background: (theme) => theme.palette.background.default,
   minHeight: "36px",
+  maskImage:
+    "linear-gradient(to right, transparent, #000 18px, #000 calc(100% - 18px), transparent)",
+  WebkitMaskImage:
+    "linear-gradient(to right, transparent, #000 18px, #000 calc(100% - 18px), transparent)",
   [`& .MuiTab-root`]: {
     textTransform: "none",
     alignItems: "center",

--- a/src/components/home/SearchRangeController.tsx
+++ b/src/components/home/SearchRangeController.tsx
@@ -92,4 +92,21 @@ const rootSx: SxProps<Theme> = {
 const toggleButtonSx: SxProps<Theme> = {
   height: 30,
   px: 2,
+  // Selected range reads in the brand yellow (#fedb00) instead of plain grey
+  "&.Mui-selected": {
+    backgroundColor: (t) =>
+      t.palette.mode === "dark"
+        ? "rgba(254, 219, 0, 0.14)"
+        : "rgba(254, 219, 0, 0.2)",
+    color: (t) => t.palette.text.primary,
+    // Gate hover to pointer devices so it can't stick after a tap on old Android
+    "@media (hover: hover)": {
+      "&:hover": {
+        backgroundColor: (t) =>
+          t.palette.mode === "dark"
+            ? "rgba(254, 219, 0, 0.2)"
+            : "rgba(254, 219, 0, 0.28)",
+      },
+    },
+  },
 };

--- a/src/components/home/SuccinctTimeReport.tsx
+++ b/src/components/home/SuccinctTimeReport.tsx
@@ -241,6 +241,21 @@ const rootSx: SxProps<Theme> = {
   gridTemplateColumns: "15% 1fr minmax(18%, max-content)",
   padding: (theme) => `${theme.spacing(0.5)} ${theme.spacing(1)}`,
   color: "rgba(0,0,0,0.87)",
+  cursor: "pointer",
+  // Tap feedback in the brand yellow (#fedb00) so a press visibly responds
+  WebkitTapHighlightColor: "transparent",
+  transition: "background-color 0.12s ease-out",
+  "@media (hover: hover)": {
+    "&:hover": {
+      backgroundColor: "rgba(254, 219, 0, 0.06)",
+    },
+  },
+  "&:active": {
+    backgroundColor: "rgba(254, 219, 0, 0.1)",
+  },
+  "@media (prefers-reduced-motion: reduce)": {
+    transition: "none",
+  },
 };
 
 const routeDestSx: SxProps<Theme> = {

--- a/src/components/home/SuccinctTimeReport.tsx
+++ b/src/components/home/SuccinctTimeReport.tsx
@@ -26,6 +26,7 @@ import {
   vibrate,
 } from "../../utils";
 import RouteNo from "../route-board/RouteNo";
+import CompanyColorDot from "../CompanyColorDot";
 import SuccinctEtas from "./SuccinctEtas";
 import useLanguage from "../../hooks/useTranslation";
 import DbContext from "../../context/DbContext";
@@ -151,6 +152,7 @@ const SuccinctTimeReport = ({
           }
           secondary={
             <Typography component="h4" variant="caption" sx={companySx}>
+              <CompanyColorDot companies={co} route={routeNo} />
               {co.map((co) => t(co)).join("+")}
             </Typography>
           }

--- a/src/components/route-board/BoardTabbar.tsx
+++ b/src/components/route-board/BoardTabbar.tsx
@@ -44,8 +44,7 @@ const BoardTabbar = ({ boardTab, onChangeTab }: BoardTabbarProps) => {
         onChange={(_, v) => onChangeTab(v, true)}
         sx={tabbarSx}
         variant="scrollable"
-        scrollButtons
-        allowScrollButtonsMobile
+        scrollButtons={false}
       >
         {Object.keys(TRANSPORT_SEARCH_OPTIONS)
           .filter((option) => isRecentSearchShown || option !== "recent")
@@ -79,6 +78,10 @@ const tabbarSx: SxProps<Theme> = {
   minHeight: "36px",
   overflow: "auto",
   maxWidth: "100%",
+  maskImage:
+    "linear-gradient(to right, transparent, #000 18px, #000 calc(100% - 18px), transparent)",
+  WebkitMaskImage:
+    "linear-gradient(to right, transparent, #000 18px, #000 calc(100% - 18px), transparent)",
   [`& .MuiTab-root`]: {
     py: 0,
     minWidth: "85px",

--- a/src/components/route-board/RouteInputPad.tsx
+++ b/src/components/route-board/RouteInputPad.tsx
@@ -125,11 +125,23 @@ const buttonSx: SxProps<Theme> = {
   width: "100%",
   fontSize: "1.8em",
   borderRadius: "unset",
+  // Each key lights up in the brand yellow (#fedb00) when pressed
+  transition: "background-color 0.1s ease-out",
   "&:selected": {
     color: (theme) => theme.palette.text.primary,
   },
-  "&:hover": {
-    backgroundColor: (theme) => theme.palette.background.paper,
+  "@media (hover: hover)": {
+    "&:hover": {
+      backgroundColor: (theme) =>
+        theme.palette.mode === "dark" ? "rgba(254, 219, 0, 0.08)" : "#fff6c4",
+    },
+  },
+  "&:active": {
+    backgroundColor: (theme) =>
+      theme.palette.mode === "dark" ? "rgba(254, 219, 0, 0.16)" : "#fdec9e",
+  },
+  "@media (prefers-reduced-motion: reduce)": {
+    transition: "none",
   },
 };
 

--- a/src/components/route-board/RouteNoCompany.tsx
+++ b/src/components/route-board/RouteNoCompany.tsx
@@ -3,6 +3,7 @@ import { Box, SxProps, Theme, Typography } from "@mui/material";
 import RouteNo from "./RouteNo";
 import useLanguage from "../../hooks/useTranslation";
 import { RouteListEntry } from "hk-bus-eta";
+import CompanyColorDot from "../CompanyColorDot";
 
 interface RouteNoCompanyProps {
   route: [string, RouteListEntry];
@@ -25,6 +26,7 @@ const RouteNoCompany = ({ route }: RouteNoCompanyProps) => {
         </Typography>
       )}
       <Typography component="h4" variant="caption" sx={companySx}>
+        <CompanyColorDot companies={route[1].co} route={routeNo} />
         {Object.keys(route[1].stops)
           .map((co) => t(co))
           .join("+")}

--- a/src/components/route-eta/StopAccordion.tsx
+++ b/src/components/route-eta/StopAccordion.tsx
@@ -227,11 +227,26 @@ const accordionSummarySx: SxProps<Theme> = {
     theme.palette.mode === "dark"
       ? theme.palette.background.default
       : "rgba(0, 0, 0, .03)",
+  transition: "background-color 0.12s ease-out",
+  "@media (hover: hover)": {
+    "&:hover": {
+      backgroundColor: "rgba(254, 219, 0, 0.06)",
+    },
+  },
   "&.Mui-expanded": {
     borderBottom: "1px solid rgba(0, 0, 0, .125)",
     minHeight: 44,
+    // Mark the open stop with a brand-yellow (#fedb00) rail; inset shadow so
+    // it adds no width and never nudges the row (matters on old devices)
+    boxShadow: (theme) =>
+      `inset 3px 0 0 0 ${
+        theme.palette.mode === "dark" ? theme.palette.primary.main : "#fedb00"
+      }`,
   },
   minHeight: 44,
+  "@media (prefers-reduced-motion: reduce)": {
+    transition: "none",
+  },
   "& .MuiAccordionSummary-content": {
     margin: "8px 0",
     flexDirection: "column",


### PR DESCRIPTION
**TL;DR** — Three small, independent visual touch-ups for the app's users (many elderly, on old low-end Android). Each sells in one image; none change layout or wording.

## 1. Tap feedback in the brand yellow
Home rows, the route-board keypad, and stop summaries had no *visual* press feedback (haptic only), which reads as lag on slow phones. They now softly tint the brand yellow on press.

![tap feedback](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/polish-tap-feedback.gif)

## 2. Colour-code the operators
A small dot in the operator's line colour (九巴 red / 城巴 yellow / 嶼巴 teal …) before the name, so companies are distinguishable at a glance. Reuses `getLineColor` — the same palette the route map already uses.

![operator dots](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/polish-operator-dots.png)

## 3. Fade the tab-bar edges instead of scroll chevrons
The board/home tab bars forced the `< >` scroll arrows on even where nothing could scroll, taking a fixed slot. Dropping them (`scrollButtons={false}`) and fading the tab strip's edges reclaims that space — an extra tab now fits — while the tabs bleeding off the faded edge still hint there are more to swipe (no button, no dead space). Top = at rest; bottom = mid-swipe revealing more.

![tab fade](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/polish-tab-chevron.png)

<details><summary>Why it's safe — perf / a11y / no-regression</summary>

- **Perf:** only `background-color` transitions on small elements (GPU-cheap, no layout/paint thrash); the expanded-stop rail is an `inset` box-shadow so it adds no width; the tab fade is a static CSS `mask-image`.
- **Touch:** hover is gated behind `@media (hover: hover)` so it can't stick after a tap on Android; `prefers-reduced-motion` disables the transition.
- **Keypad tint:** the keys sit on a yellow container, so an opaque soft-yellow is used in light mode (a transparent tint would reveal the container and read full-yellow); dark mode keeps a subtle transparent tint.
- **Dots:** `aria-hidden`, decorative — the operator name text sits beside it, so colour is never the sole carrier. Bordered so pale CTB yellow stays visible on white.
- `tsc` + `eslint` clean; no dependency changes. The three are separate commits, cherry-pickable individually.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added color swatches next to company names and route labels for easier visual identification.

* **UI Improvements**
  * Updated tab bars, buttons, and list items with brand-yellow highlights, smoother interactions, and improved edge fading.
  * Refined hover, tap, and expanded-state styling across route search and stop details for a more polished experience.

* **Accessibility**
  * Improved motion behavior by reducing animations for users who prefer reduced motion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->