### PR TITLE
Mark nearest-following favourites with a location icon

### DIFF
--- a/src/components/home/SuccinctTimeReport.tsx
+++ b/src/components/home/SuccinctTimeReport.tsx
@@ -1,5 +1,6 @@
 import {
   DeleteOutline as DeleteIcon,
+  MyLocation as NearestIcon,
   Reorder as ReorderIcon,
 } from "@mui/icons-material";
 import {
@@ -37,6 +38,7 @@ interface DistAndFareProps {
   faresHoliday: string[] | null;
   joyYouFare: string;
   seq: number;
+  isNearest: boolean;
 }
 
 const DistAndFare = ({
@@ -46,6 +48,7 @@ const DistAndFare = ({
   faresHoliday,
   joyYouFare,
   seq,
+  isNearest,
 }: DistAndFareProps) => {
   const { t } = useTranslation();
   const { geoPermission, geolocation, manualGeolocation } =
@@ -71,6 +74,9 @@ const DistAndFare = ({
 
   return (
     <>
+      {isNearest && (
+        <NearestIcon sx={nearestIconSx} titleAccess={t("最近車站")} />
+      )}
       {name +
         " - " +
         distance.toFixed(decimalPlace) +
@@ -86,6 +92,8 @@ interface SuccinctTimeReportProps {
   etas?: Eta[];
   mode?: ManageMode | "time";
   onDelete?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  // source list this row was drawn from; enables the nearest-following marker
+  nearestFrom?: string[];
 }
 
 const SuccinctTimeReport = ({
@@ -93,6 +101,7 @@ const SuccinctTimeReport = ({
   etas = undefined,
   mode = "time",
   onDelete = undefined,
+  nearestFrom = undefined,
 }: SuccinctTimeReportProps) => {
   const { t } = useTranslation();
   const language = useLanguage();
@@ -102,6 +111,10 @@ const SuccinctTimeReport = ({
   } = useContext(DbContext);
   const [routeNo] = routeId.split("-");
   const [routeKey, seq] = routeId.split("/");
+  // nearest-following ("star-the-line") row: its seq-less form is in the source
+  // list but the formatHandling-resolved routeKey/seq is not, unlike a pinned row
+  const src = nearestFrom ?? [];
+  const isNearest = src.includes(routeKey) && !src.includes(routeId);
   const { co, stops, dest, fares, faresHoliday, serviceType } =
     routeList[routeKey] || DEFAULT_ROUTE;
   const stopId = getStops(co, stops)[parseInt(seq, 10)];
@@ -175,6 +188,7 @@ const SuccinctTimeReport = ({
               faresHoliday={faresHoliday}
               joyYouFare={joyYouFare}
               seq={parseInt(seq, 10)}
+              isNearest={isNearest}
             />
           }
           secondaryTypographyProps={{
@@ -273,4 +287,10 @@ const specialTripSx: SxProps<Theme> = {
   color: (theme) => theme.palette.text.secondary,
   fontSize: "0.6rem",
   marginLeft: "8px",
+};
+
+const nearestIconSx: SxProps<Theme> = {
+  fontSize: "1rem",
+  verticalAlign: "text-bottom",
+  marginRight: "2px",
 };

--- a/src/components/home/lists/SavedRouteList.tsx
+++ b/src/components/home/lists/SavedRouteList.tsx
@@ -78,6 +78,7 @@ const SavedRouteList = ({ isFocus }: SavedRouteListProps) => {
             <SuccinctTimeReport
               key={`route-shortcut-${idx}`}
               routeId={selectedRoute}
+              nearestFrom={savedEtas}
             />
           )
       )}

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -135,6 +135,7 @@ const resources = {
       綜合: "All",
       常用: "Starred",
       附近: "Nearby",
+      最近車站: "The nearest stop",
       以鏈結分享: "Share Link",
       以圖片分享: "Share Image",
       隱私權聲明: "Privacy Policy",


### PR DESCRIPTION
On the Starred (常用) list, a favourite saved as a **line** (shows your nearest stop, moves as you walk) and one pinned to a **specific stop** render identically. This marks the follow-me row with a `MyLocation` icon so the two are distinguishable. Addresses #84 / #85.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/nearest-before.png) | ![after](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/nearest-after.png) |

Same route (6D) saved both ways; GPS at Mei Foo. ⌖ marks the follow-me row; the pinned row stays plain.

<details>
<summary>How it tells them apart</summary>

A follow-me favourite has no stop index in `savedEtas`; `formatHandling` resolves it to `routeKey/<nearestSeq>`, so by render time it looks identical to a pinned `routeKey/seq`. The marker keys off the still-present seq-less form — `savedEtas.includes(routeKey) && !savedEtas.includes(routeId)` — passed into `SuccinctTimeReport` per source-list, so Collections / manage / pin views are untouched. Verified empirically (headless, spoofed GPS): Starred badges the follow-me row only; a Collection row pinned to the same globally-starred route stays unbadged.
</details>

Open to your call: the glyph (`MyLocation` vs `NearMe`/`LocationOn`), and scope (Starred only here — happy to extend to Collections per #84). One edge: if your nearest stop equals a stop you also pinned, the two dedupe to a single (unbadged) row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
