### PR TITLE
Fix spurious multi-km loops in some route polylines (e.g. 6C, 88K)

### DIFF
--- a/src/hooks/useRoutePath.tsx
+++ b/src/hooks/useRoutePath.tsx
@@ -1,6 +1,7 @@
 import { StopListEntry } from "hk-bus-eta";
 import { useContext, useEffect, useState } from "react";
 import DbContext from "../context/DbContext";
+import { getDistance } from "../utils";
 
 interface GeoJsonType extends GeoJSON.GeoJsonObject {
   features?: Array<{
@@ -11,6 +12,31 @@ interface GeoJsonType extends GeoJSON.GeoJsonObject {
     };
   }>;
 }
+
+// Collapse a spurious "doubling-back" loop in the trailing CSDI waypoint part(s)
+// to a straight chord (e.g. 6C draws an ~8km loop between two terminus stops 35m apart).
+const dropSpuriousTail = (json: GeoJsonType): GeoJsonType => {
+  const geometry = json?.features?.[0]?.geometry;
+  if (geometry?.type !== "MultiLineString") return json;
+  const parts = geometry.coordinates as unknown as [number, number][][];
+  const dist = (a: [number, number], b: [number, number]) =>
+    getDistance({ lat: a[1], lng: a[0] }, { lat: b[1], lng: b[0] });
+  for (let i = parts.length - 1; i > 0; i--) {
+    const part = parts[i];
+    if (part.length < 2) break;
+    let length = 0;
+    let excursion = 0;
+    for (let j = 1; j < part.length; j++) length += dist(part[j - 1], part[j]);
+    for (const p of part) excursion = Math.max(excursion, dist(p, part[0]));
+    const span = dist(part[0], part[part.length - 1]);
+    if (length > 500 && excursion > 800 && excursion > 2 * Math.max(span, 30)) {
+      parts[i] = [part[0], part[part.length - 1]];
+    } else {
+      break;
+    }
+  }
+  return json;
+};
 
 export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
   const [geoJson, setGeoJson] = useState<GeoJsonType | null>(null);
@@ -57,7 +83,7 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
       fetch(`https://hkbus.github.io/route-waypoints/${waypointsFile}`)
         .then((r) => r.json())
         .then((json) => {
-          setGeoJson(json);
+          setGeoJson(dropSpuriousTail(json));
         })
         .catch(() => {
           setFallbackGeoJson();


### PR DESCRIPTION
Some routes draw a big stray loop on the map. **6C** is the clearest: it loops ~8 km out to To Kwa Wan and back, between two terminus stops that are only **35 m** apart.

| before | after (this PR) |
|:--:|:--:|
| <img src="https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/pr/6c-before.png" width="380"> | <img src="https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/pr/6c-after.png" width="380"> |

**Why it happens:** the geometry from `route-waypoints` (the CSDI/TD government source) sometimes has a spurious "doubling-back" loop in its final segment — it looks like a GPS recording run that overshot the terminus and looped back. hkbus draws the waypoints as-is, so the loop shows up on the map.

**What this does:** a small guard in `useRoutePath`. After the waypoints are fetched, if the **last** `MultiLineString` part doubles far back on itself (it's long, and its farthest point is well beyond its two endpoints), collapse that part to a straight line between its endpoints. Only trailing bad parts are touched — every other part is drawn exactly as before.

Validated against KMB's official route line:

| route | raw | after | KMB |
|--|--|--|--|
| 6C | 20.9 km | **10.0 km** | 10.1 km |
| 88K | 12.1 km | **7.2 km** | 7.1 km |

This clears the two terminus-loop clusters — **8.2 km** (6C, 6F, 11B, 2E, 61X, 75X, 85A) and **5.05 km** (88K, A46).

Reuses the existing `getDistance` util; **~30 lines, one file, no new dependency.** Tested on a local build (screenshots above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route rendering by removing certain spurious doubling-back loops from fetched routes.
  * Simplified affected route segments to provide a cleaner, more accurate path display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->