### PR TITLE
a11y: add accessible names to unlabelled controls

### DIFF
--- a/src/components/home/SuccinctTimeReport.tsx
+++ b/src/components/home/SuccinctTimeReport.tsx
@@ -197,7 +197,10 @@ const SuccinctTimeReport = ({
         )}
         {mode === "edit" && (
           <Box sx={iconContainerSx}>
-            <IconButton onClick={(e) => onDelete && onDelete(e)}>
+            <IconButton
+              aria-label={t("移除")}
+              onClick={(e) => onDelete && onDelete(e)}
+            >
               <DeleteIcon />
             </IconButton>
           </Box>

--- a/src/components/layout/NoticeCard.tsx
+++ b/src/components/layout/NoticeCard.tsx
@@ -101,8 +101,13 @@ const NoticeCard = () => {
           value={viewIdx}
           onChange={(_, v) => setViewIdx(v)}
         >
-          {state.map((_, idx) => (
-            <Tab key={`notice-tab-${idx}`} label={""} value={idx} />
+          {state.map((notice, idx) => (
+            <Tab
+              key={`notice-tab-${idx}`}
+              aria-label={notice.content[language][0] ?? String(idx + 1)}
+              label={""}
+              value={idx}
+            />
           ))}
         </Tabs>
         <SwipeableViews

--- a/src/components/route-search/AddressInput.tsx
+++ b/src/components/route-search/AddressInput.tsx
@@ -67,6 +67,7 @@ const AddressInput = ({
       value={value}
       loadOptions={loadAddress}
       placeholder={placeholder}
+      aria-label={placeholder}
       onChange={onChange}
       classNamePrefix="react-select"
     />


### PR DESCRIPTION
Three interactive controls render with no accessible name, so screen-reader users hear only "button" / "tab" (or an unlabelled text field) and can't tell what they do or which is which. This adds `aria-label`s only — **no visual or behavioural change**.

**Why / policy:** [WCAG 2.1 **4.1.2 Name, Role, Value** (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html) requires every UI control to expose an accessible name to assistive tech; the P2P search fields additionally fall under [**3.3.2 Labels or Instructions** (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html) (a placeholder is not a label). Found with axe-core.

| Control | File | Announced as (before) |
|---|---|---|
| Notice-carousel pagination tabs | `NoticeCard.tsx` | "tab", no name (`label=""`) |
| P2P search fields 你的位置 / 目的地 | `AddressInput.tsx` | unlabelled text field |
| Saved-route delete button (edit mode) | `SuccinctTimeReport.tsx` | "button", no name |

<details><summary>How (kept minimal, no visual change)</summary>

- `NoticeCard`: `aria-label={notice.content[language][0] ?? String(idx + 1)}` on the pagination `<Tab>`s; `label=""` kept so they stay dots. (The `?? String(idx + 1)` fallback matters: `content[language]` is typed `string[]` with no non-empty guarantee, and an `undefined` aria-label would silently leave the tab unnamed again.)
- `AddressInput`: `aria-label={placeholder}` — react-select v5 forwards a top-level `aria-label` to the input's accessible name.
- `SuccinctTimeReport`: `aria-label={t("移除")}` (existing i18n key → "Remove").
</details>

<details><summary>Verification</summary>

axe-core (WCAG 2.0/2.1 A/AA) on a local production build, mobile viewport:
- Home `button-name`: **6 → 1**.
- Search `label` + `label-title-only`: **4 → 0** (inputs read "Your Location" / "Destination").

`tsc --noEmit`, `eslint --max-warnings 0`, and `prettier --check` all clean.
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added accessible labels to the remove action in time reports.
  * Improved navigation of notices with descriptive tab labels.
  * Added an accessible label to the address search input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->