### PR TITLE
a11y: name the notice close and P2P reverse buttons

### DIFF
--- a/src/components/layout/NoticeCard.tsx
+++ b/src/components/layout/NoticeCard.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
 } from "@mui/material";
 import WarnIcon from "@mui/icons-material/Warning";
+import { useTranslation } from "react-i18next";
 import useLanguage from "../../hooks/useTranslation";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { iOSRNWebView } from "../../utils";
@@ -30,6 +31,7 @@ interface NoticeCardState {
 
 const NoticeCard = () => {
   const language = useLanguage();
+  const { t } = useTranslation();
   const [state, setState] = useState<NoticeCardState[]>([]);
   const [viewIdx, setViewIdx] = useState<number>(0);
   const [closeNoticeIds, setCloseNoticeIds] = useState<string[]>(
@@ -129,7 +131,11 @@ const NoticeCard = () => {
           ))}
         </SwipeableViews>
       </Box>
-      <IconButton size="small" onClick={closeNotice(state[viewIdx].id)}>
+      <IconButton
+        size="small"
+        aria-label={t("關閉通知")}
+        onClick={closeNotice(state[viewIdx].id)}
+      >
         <CloseIcon />
       </IconButton>
     </Paper>

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -24,6 +24,8 @@ const resources = {
       往: "To",
       分鐘: "min",
       移除: "Remove",
+      關閉通知: "Close notice",
+      對調起點及終點: "Swap origin and destination",
       跳至主要內容: "Skip to main content",
       輸入巴士路線號碼搜尋: "Search by entering a bus route number",
       離線: "Offline",

--- a/src/pages/RouteSearchPage.tsx
+++ b/src/pages/RouteSearchPage.tsx
@@ -327,7 +327,11 @@ const RouteSearch = () => {
             stopList={stopList}
           />
         </Box>
-        <Button sx={reverseIconSx} onClick={handleReverseClick}>
+        <Button
+          sx={reverseIconSx}
+          aria-label={t("對調起點及終點")}
+          onClick={handleReverseClick}
+        >
           <ChangeCircleIcon />
         </Button>
       </Box>


### PR DESCRIPTION
Two more icon-only controls render with no accessible name, so screen-reader users hear only "button" and can't tell what they do. Adds `aria-label`s (with matching i18n keys) — **no visual or behavioural change**. Follows #273.

**Why / policy:** [WCAG 2.1 **4.1.2 Name, Role, Value** (Level A)](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html) — every UI control must expose an accessible name to assistive tech. Found with axe-core.

| Control | File | Announced as (before) |
|---|---|---|
| Notice-card dismiss button | `NoticeCard.tsx` | "button", no name |
| P2P search reverse (start ↔ destination) | `RouteSearchPage.tsx` | "button", no name |

<details><summary>How</summary>

- `NoticeCard`: `aria-label={t("關閉通知")}` on the close `IconButton`.
- `RouteSearchPage`: `aria-label={t("對調起點及終點")}` on the reverse `Button`.
- `translation.js`: two new CJK keys in the `en` block (`Close notice`, `Swap origin and destination`); zh falls back to the key, matching the existing pattern (`keySeparator:false`, no `fallbackLng`).
</details>

<details><summary>Verification</summary>

axe-core on a local production build, then DOM-probed: the notice close button reads "Close notice", the reverse button reads "Swap origin and destination", and the search page has **0** unnamed buttons. `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check` all clean.
</details>