### PR TITLE
Fix home tab-bar edge fade showing white instead of the yellow theme background

### DIFF
--- a/src/components/home/HomeTabbar.tsx
+++ b/src/components/home/HomeTabbar.tsx
@@ -83,10 +83,12 @@ export const isHomeTab = (
 const tabbarSx: SxProps<Theme> = {
   background: (theme) => theme.palette.background.default,
   minHeight: "36px",
-  maskImage:
-    "linear-gradient(to right, transparent, #000 18px, #000 calc(100% - 18px), transparent)",
-  WebkitMaskImage:
-    "linear-gradient(to right, transparent, #000 18px, #000 calc(100% - 18px), transparent)",
+  [`& .MuiTabs-scroller`]: {
+    maskImage:
+      "linear-gradient(to right, transparent, #000 18px, #000 calc(100% - 18px), transparent)",
+    WebkitMaskImage:
+      "linear-gradient(to right, transparent, #000 18px, #000 calc(100% - 18px), transparent)",
+  },
   [`& .MuiTab-root`]: {
     textTransform: "none",
     alignItems: "center",


### PR DESCRIPTION
**TL;DR** — The home tab-bar (附近 / 常用 / 收藏 / …) scroll fade currently fades to **white** at the left/right edges instead of the yellow theme colour. Regression from #276. One-line relocation of the mask fixes it (net +2 lines: mask moved from the `Tabs` root onto its `.MuiTabs-scroller` child).

![before/after — before fades to white, after stays yellow](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-277-assets/tabbar-fade-before-after.png)

### Root cause
#276 added the horizontal-scroll fade as a `maskImage` on the **`Tabs` root**. But that same root paints the tab-bar background:

```ts
background: (theme) => theme.palette.background.default,  // light mode = "#fedb00" (yellow)
```

A mask makes the element transparent at its edges — so it faded the **yellow root background itself** to transparent, exposing whatever is painted behind the bar. On `HomePage` that is the `<Paper>` with `background: "white"` (light mode) → the fade reads **white**.

### Fix
Move the mask from the root onto the inner **`.MuiTabs-scroller`**. The root keeps its (unmasked) yellow background; only the scrolling labels/icons fade at the edges, revealing the root's own yellow instead of the white page behind.

<details><summary>Before / after (edge behaviour)</summary>

| | left/right 18px edge |
|---|---|
| **Before (`mask` on root)** | yellow bar → **transparent** → white `Paper` shows through ⇒ **white fade** ❌ |
| **After (`mask` on `.MuiTabs-scroller`)** | root stays solid **yellow**; only labels/icons fade ⇒ **yellow fade** ✅ |

The image above is a faithful repro of the MUI Tabs DOM (`root › .MuiTabs-scroller › .MuiTabs-flexContainer › tabs`) rendered on a white page — buggy variant fades to white, fixed variant stays yellow to the edge.
</details>

<details><summary>Second-lineage review (Codex, gpt-5.x) — PASS</summary>

- `.MuiTabs-scroller` is the correct **stable slot class** in this repo's `@mui/material@5.15.11` (`scrollableX` is a *state* class on the same element, not a different wrapper).
- Indicator underline: the old root mask already covered it; relocation only changes the revealed edge colour (yellow vs white) — no new regression.
- Dark mode: root and `Paper` are both `background.default` (#000) → relocation is neutral.
- `sx` nested selector is valid and additive — sets only `maskImage`/`WebkitMaskImage`, does not clobber MUI's overflow/scrollbar-hiding styles.
- Sole caveat: would fade a *visible* scrollbar if `visibleScrollbar` were set — not used here.
</details>

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>