### PR TITLE
Mark nearest-following stops in Collection List with a location icon

### DIFF
--- a/src/components/home/lists/CollectionRouteList.tsx
+++ b/src/components/home/lists/CollectionRouteList.tsx
@@ -70,6 +70,7 @@ const CollectionRouteList = ({
             <SuccinctTimeReport
               key={`route-shortcut-${idx}`}
               routeId={selectedRoute}
+              nearestFrom={collection.list}
             />
           )
       )}

--- a/src/components/home/lists/HomeRouteListDropDown.tsx
+++ b/src/components/home/lists/HomeRouteListDropDown.tsx
@@ -9,12 +9,14 @@ import {
 interface HomeRouteListDropDownProps {
   name: string;
   routeStrings: string;
+  nearestFrom?: string[];
   defaultExpanded?: boolean;
 }
 
 const HomeRouteListDropDown = ({
   name,
   routeStrings,
+  nearestFrom,
   defaultExpanded = true,
 }: HomeRouteListDropDownProps) => {
   const [expaned, setExpanded] = useState<boolean>(defaultExpanded);
@@ -42,6 +44,7 @@ const HomeRouteListDropDown = ({
                 <SuccinctTimeReport
                   key={`route-${name}-${idx}`}
                   routeId={selectedRoute}
+                  nearestFrom={nearestFrom}
                 />
               )
           )}

--- a/src/components/home/lists/SmartCollectionRouteList.tsx
+++ b/src/components/home/lists/SmartCollectionRouteList.tsx
@@ -63,11 +63,12 @@ const SmartCollectionRouteList = ({
 
   return (
     <Box sx={rootSx}>
-      {collections.map(({ name, routes, defaultExpanded }, idx) => (
+      {collections.map(({ name, routes, nearestFrom, defaultExpanded }, idx) => (
         <HomeRouteListDropDown
           key={`collection-${idx}`}
           name={name}
           routeStrings={routes}
+          nearestFrom={nearestFrom}
           defaultExpanded={defaultExpanded}
         />
       ))}
@@ -89,6 +90,7 @@ export default SmartCollectionRouteList;
 interface ParsedCollection {
   name: string;
   routes: string;
+  nearestFrom: string[];
   defaultExpanded: boolean;
 }
 
@@ -132,6 +134,7 @@ const getCollections = ({
     }))
     .map((v) => ({
       ...v,
+      nearestFrom: v.routes,
       routes: formatHandling(
         v.routes,
         isTodayHoliday,

--- a/src/components/home/lists/SmartCollectionRouteList.tsx
+++ b/src/components/home/lists/SmartCollectionRouteList.tsx
@@ -63,15 +63,17 @@ const SmartCollectionRouteList = ({
 
   return (
     <Box sx={rootSx}>
-      {collections.map(({ name, routes, nearestFrom, defaultExpanded }, idx) => (
-        <HomeRouteListDropDown
-          key={`collection-${idx}`}
-          name={name}
-          routeStrings={routes}
-          nearestFrom={nearestFrom}
-          defaultExpanded={defaultExpanded}
-        />
-      ))}
+      {collections.map(
+        ({ name, routes, nearestFrom, defaultExpanded }, idx) => (
+          <HomeRouteListDropDown
+            key={`collection-${idx}`}
+            name={name}
+            routeStrings={routes}
+            nearestFrom={nearestFrom}
+            defaultExpanded={defaultExpanded}
+          />
+        )
+      )}
       {!collections.reduce(
         (acc, { routes }) =>
           acc || routes.split("|").filter((v) => Boolean(v)).length > 0,


### PR DESCRIPTION
With referencing to to PR (#271) and [Github AI Suggestion](https://github.com/copilot/share/c022118c-41c4-84b6-a843-b440a09b4830), I made nearest-following stops in self-created Collection (收藏) List with a location icon if Nearest Stop is bookmarked.

On the self-created Collection (收藏) list, a favourite saved as a **line** (shows your nearest stop, moves as you walk) and one pinned to a **specific stop** render identically. This marks the follow-me row with a `MyLocation` icon so the two are distinguishable. 

Before | After
<img width="225" height="455" alt="image" src="https://github.com/user-attachments/assets/2f5eca0b-7a72-4609-bea2-356b669c5a1f" />　　<img width="225" height="455" alt="image" src="https://github.com/user-attachments/assets/bf9ab55a-9ea6-4f96-9580-3973dd569c36" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route time reports by providing additional collection context, enabling more accurate nearest-location information across collection lists and dropdown route summaries.
  * Updated the smart collection routing view to derive and pass the nearest-location data through to route report components for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->