### PR TITLE
Revert "Suppress native keyboard on header search via inputmode="none""

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -174,7 +174,6 @@ const Header = () => {
         id="searchInput"
         sx={searchRouteInputSx}
         type="text"
-        inputProps={{ inputMode: "none" }}
         ref={inputRef}
         value={searchRoute}
         placeholder={t("路線")}


### PR DESCRIPTION
Reverts hkbus/hk-independent-bus-eta#267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the search field’s standard input behavior, improving compatibility with device keyboards and text entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->