### PR TITLE
fix: P2P Route Search map potentially zooming out to nowhere

### DIFF
--- a/src/components/map/maplibre/SearchMap.tsx
+++ b/src/components/map/maplibre/SearchMap.tsx
@@ -47,8 +47,14 @@ const MapEffects = ({ center, start, end }: MapEffectsProps) => {
     if (center) {
       m.flyTo(center);
     } else if (end) {
-      const sw = { lat: Math.min(start.lat, end.lat), lng: Math.min(start.lng, end.lng) };
-      const ne = { lat: Math.max(start.lat, end.lat), lng: Math.max(start.lng, end.lng) };
+      const sw = {
+        lat: Math.min(start.lat, end.lat),
+        lng: Math.min(start.lng, end.lng),
+      };
+      const ne = {
+        lat: Math.max(start.lat, end.lat),
+        lng: Math.max(start.lng, end.lng),
+      };
       m.fitBounds([sw, ne], { padding: 40 });
     }
   }, [center, start, end, m]);

--- a/src/components/map/maplibre/SearchMap.tsx
+++ b/src/components/map/maplibre/SearchMap.tsx
@@ -47,7 +47,9 @@ const MapEffects = ({ center, start, end }: MapEffectsProps) => {
     if (center) {
       m.flyTo(center);
     } else if (end) {
-      m.fitBounds([start, end], { padding: 40 });
+      const sw = { lat: Math.min(start.lat, end.lat), lng: Math.min(start.lng, end.lng) };
+      const ne = { lat: Math.max(start.lat, end.lat), lng: Math.max(start.lng, end.lng) };
+      m.fitBounds([sw, ne], { padding: 40 });
     }
   }, [center, start, end, m]);
   return null;


### PR DESCRIPTION
If the user picks an ending point that is located more South-West than the starting point, the map view would try to fit an area that wraps around the globe instead, since maplibre always expects the point to be given in the order SW & NE.

<img width="479" height="953" alt="image" src="https://github.com/user-attachments/assets/688373f8-3eed-4deb-b688-67c6c2185e5e" />

This PR adds some extra guarding to ensure the points are always ordered correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved map viewport fitting when no center is provided.
  - Ensures both locations are fully visible by calculating the correct southwest and northeast map boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->