### PR TITLE
Accept "closed" in the isGeoPermission guard

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -159,6 +159,7 @@ const isGeoPermission = (input: unknown): input is GeoPermission => {
     input === "force-opening" ||
     input === "granted" ||
     input === "denied" ||
+    input === "closed" ||
     input === null
   );
 };


### PR DESCRIPTION
`isGeoPermission` is missing one member of the `GeoPermission` type it guards, so turning location off is silently discarded on every reload.

`GeoPermission` (`AppContext.tsx:31-32`) includes `"closed"`, but the guard at `:156-164` doesn't test for it. Settings persists the literal `"closed"` when the user turns location off; on rehydrate the guard rejects it and `geoPermission` becomes `null`.

<details>
<summary>Round trip, and why it is user-visible on the app builds</summary>

Driving the real chain — persist (`:750`, `state.geoPermission ?? "null"`) → rehydrate (`:214`/`:227`, `isGeoPermission(x) ? x : null`) → the RN branch (`ReactNativeContext.tsx:147-165`):

```
user turns location OFF   -> geoPermission = "closed"
before:  persisted "closed" -> restored null  -> posts start-geolocation
after:   persisted "closed" -> restored "closed" -> posts stop-geolocation
```

On plain web this is invisible, because every consumer tests `=== "granted"` or `!== "denied"`. It shows up in the iOS/Android WebView builds, where `ReactNativeContext` is the only consumer that distinguishes `null` from `"closed"`: every launch posts the start message and the `"closed"` branch is unreachable after a restart, while Settings still displays 「關閉」.

All six members round-trip after the change, and `"Closed"` / `"CLOSED"` / `" closed"` / `"null"` / `""` / `undefined` are still rejected.

For context, `2bdad8f` added `"force-opening"` to both the type and this guard — `"closed"` looks like it was simply missed at the same time.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed geolocation permission state handling so the “closed” status is recognized correctly.
  * Preserved the saved geolocation permission state when restoring application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->