### PR TITLE
Fix crash on deep link to an unknown stop

### DIFF
--- a/src/pages/StopEtaListPage.tsx
+++ b/src/pages/StopEtaListPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { Navigate, useParams } from "react-router-dom";
 import StopRouteList from "../components/bookmarked-stop/StopRouteList";
 import { useContext, useMemo } from "react";
 import DbContext from "../context/DbContext";
@@ -30,6 +30,8 @@ const StopEtaListPage = () => {
 
     return ret;
   }, [routeList, stopId, stopMap]);
+
+  if (!stopList[stopId!]) return <Navigate to={`/${language}`} replace />;
 
   return (
     <Box height="100%" display="flex" flexDirection="column">


### PR DESCRIPTION
Opening `/{lang}/stop/{id}` for a stop not in the local DB throws during render and crashes to the ErrorBoundary — Retry just reloads the same URL, so there's no way back.

`StopEtaListPage.tsx:37` reads `stopList[stopId!].name[language]` with no guard; sibling code (`StopDialog.tsx:75`, `BookmarkedStopPage.tsx:36`) already guards this. Adds the same guard and redirects home.

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/issue94-before.png" width="320"> | <img src="https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/issue94-after.png" width="320"> |
