### PR TITLE
Replace instead of push on fuzzy route redirect

### DIFF
--- a/src/pages/RouteEtaPage.tsx
+++ b/src/pages/RouteEtaPage.tsx
@@ -161,7 +161,9 @@ const RouteEta = () => {
 
   useEffect(() => {
     if (id!.toUpperCase() !== routeId.toUpperCase()) {
-      navigate(`/${language}/route/${routeId.toLowerCase()}`);
+      navigate(`/${language}/route/${routeId.toLowerCase()}`, {
+        replace: true,
+      });
     }
   }, [id, routeId, language, navigate]);
 


### PR DESCRIPTION
The fuzzy route-id redirect pushes instead of replacing, so Back returns to the stale URL, the effect re-fires, and the user gets pushed forward again — a back-button trap. The same file already passes `{ replace: true }` at `:122` and `:137`; this makes the fuzzy redirect consistent with those.

Verified in a booted app: before, pressing Back twice from the redirected URL stays trapped on it; after, Back escapes to `/en/`. Likely real trigger: a saved-ETA row whose stored route key no longer exists after a DB regeneration.
