### PR TITLE
Fix route sorting for letter-prefixed routes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -449,15 +449,11 @@ export const routeSortFunc = (
   }
 
   // Remove all A-Z, smaller number should come first
-  if (
-    parseInt(aRoute[0].replace(/[a-z]/gi, ""), 10) >
-    parseInt(bRoute[0].replace(/[a-z]/gi, ""), 10)
-  ) {
+  const aNum = parseInt(aRoute[0].replace(/[a-z]/gi, ""), 10);
+  const bNum = parseInt(bRoute[0].replace(/[a-z]/gi, ""), 10);
+  if (aNum > bNum) {
     return 1;
-  } else if (
-    parseInt(aRoute[0].replace(/[a-z]/gi, ""), 10) <
-    parseInt(bRoute[0].replace(/[a-z]/gi, ""), 10)
-  ) {
+  } else if (aNum < bNum) {
     return -1;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -449,9 +449,15 @@ export const routeSortFunc = (
   }
 
   // Remove all A-Z, smaller number should come first
-  if (parseInt(aRoute[0], 10) > parseInt(bRoute[0], 10)) {
+  if (
+    parseInt(aRoute[0].replace(/[a-z]/gi, ""), 10) >
+    parseInt(bRoute[0].replace(/[a-z]/gi, ""), 10)
+  ) {
     return 1;
-  } else if (parseInt(aRoute[0], 10) < parseInt(bRoute[0], 10)) {
+  } else if (
+    parseInt(aRoute[0].replace(/[a-z]/gi, ""), 10) <
+    parseInt(bRoute[0].replace(/[a-z]/gi, ""), 10)
+  ) {
     return -1;
   }
 
@@ -474,7 +480,7 @@ export const routeSortFunc = (
   }
 
   // Smaller service Type should come first
-  return aRoute[1] > bRoute[1] ? 1 : -1;
+  return parseInt(aRoute[1], 10) - parseInt(bRoute[1], 10) || 0;
 };
 
 export const iOSRNWebView = (): boolean => {


### PR DESCRIPTION
`routeSortFunc` never applies numeric ordering to letter-prefixed routes, and its final comparator returns `-1` for equal elements (violates antisymmetry, reverses tie-runs).

Two defects: the "Remove all A-Z" tier is byte-identical to the tier above it, so `parseInt("A29")` is `NaN` and it never branches; and `aRoute[1] > bRoute[1] ? 1 : -1` returns `-1` on equals.

Verified: searching `A2` went from `A29, A29, A28, A28, A26...` to `A20, A20, A21, A21, A22...`. Affects airport/night/express families (A, N, E, S, W, X); purely numeric routes unaffected.
