### PR TITLE
Cancel stale ETA fetch on route change

### DIFF
--- a/src/hooks/useEtas.tsx
+++ b/src/hooks/useEtas.tsx
@@ -36,7 +36,6 @@ export const useEtas = (routeId: string, disable: boolean = false) => {
 
   useEffect(() => {
     if (disable) return;
-    setEtas(null);
     const fetchEtaInterval = setInterval(() => {
       fetchData();
     }, refreshInterval);

--- a/src/hooks/useEtas.tsx
+++ b/src/hooks/useEtas.tsx
@@ -13,9 +13,10 @@ export const useEtas = (routeId: string, disable: boolean = false) => {
   const routeObj = routeList[routeKey] || DefaultRoute;
   const [etas, setEtas] = useState<Eta[] | null>(null);
   const language = useLanguage();
-  const isMounted = useRef<boolean>(false);
+  const runId = useRef<number>(0);
 
   const fetchData = useCallback(() => {
+    const id = runId.current;
     if (!isVisible || navigator.userAgent === "prerendering") {
       // skip if prerendering
       setEtas(null);
@@ -29,13 +30,13 @@ export const useEtas = (routeId: string, disable: boolean = false) => {
       holidays,
       serviceDayMap,
     }).then((_etas) => {
-      if (isMounted.current) setEtas(_etas);
+      if (id === runId.current) setEtas(_etas);
     });
   }, [isVisible, language, routeObj, seq, stopList, holidays, serviceDayMap]);
 
   useEffect(() => {
     if (disable) return;
-    isMounted.current = true;
+    setEtas(null);
     const fetchEtaInterval = setInterval(() => {
       fetchData();
     }, refreshInterval);
@@ -43,7 +44,7 @@ export const useEtas = (routeId: string, disable: boolean = false) => {
     fetchData();
 
     return () => {
-      isMounted.current = false;
+      runId.current += 1;
       clearInterval(fetchEtaInterval);
     };
   }, [routeId, fetchData, refreshInterval, disable]);


### PR DESCRIPTION
`useEtas` guards its async write with a single `isMounted` ref shared across effect runs, so an in-flight fetch for the previous route can write its ETAs into the next one — route/destination/stop stay correct, only the minutes are wrong, so it reads as bad data rather than a bug.

Fix: a monotonic generation counter. `isMounted` is the idiom in `useStopEtas`/`useNotices`/`Weather`, but a boolean cannot tell "unmounted" from "route changed", which is the bug. `AbortController` doesn't apply — `fetchEtas` takes no signal.

Timing race, not staged in a browser like the others here.
