### PR TITLE
Ignore late waypoints response after route change

### DIFF
--- a/src/hooks/useRoutePath.tsx
+++ b/src/hooks/useRoutePath.tsx
@@ -20,7 +20,7 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
   const { gtfsId, bound, co, route, dest } = routeList[routeId];
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
     let waypointsFile = "";
     if (gtfsId) {
       waypointsFile = `${gtfsId}-${
@@ -55,19 +55,19 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
     if (waypointsFile === "") {
       setFallbackGeoJson();
     } else {
-      fetch(`https://hkbus.github.io/route-waypoints/${waypointsFile}`)
+      fetch(`https://hkbus.github.io/route-waypoints/${waypointsFile}`, {
+        signal: controller.signal,
+      })
         .then((r) => r.json())
         .then((json) => {
-          if (cancelled) return;
           setGeoJson(json);
         })
         .catch(() => {
-          if (cancelled) return;
-          setFallbackGeoJson();
+          if (!controller.signal.aborted) setFallbackGeoJson();
         });
     }
     return () => {
-      cancelled = true;
+      controller.abort();
       setGeoJson(null);
     };
   }, [routeId, gtfsId, bound, co, stops, dest, route]);

--- a/src/hooks/useRoutePath.tsx
+++ b/src/hooks/useRoutePath.tsx
@@ -20,6 +20,7 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
   const { gtfsId, bound, co, route, dest } = routeList[routeId];
 
   useEffect(() => {
+    let cancelled = false;
     let waypointsFile = "";
     if (gtfsId) {
       waypointsFile = `${gtfsId}-${
@@ -57,13 +58,16 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
       fetch(`https://hkbus.github.io/route-waypoints/${waypointsFile}`)
         .then((r) => r.json())
         .then((json) => {
+          if (cancelled) return;
           setGeoJson(json);
         })
         .catch(() => {
+          if (cancelled) return;
           setFallbackGeoJson();
         });
     }
     return () => {
+      cancelled = true;
       setGeoJson(null);
     };
   }, [routeId, gtfsId, bound, co, stops, dest, route]);


### PR DESCRIPTION
`useRoutePath` has no cancellation, so a waypoints response landing after the user changes route overwrites the current polyline — the map draws one route's line through another's stop markers until the next navigation. A failed request stomps it too, via the unguarded `.catch` calling `setFallbackGeoJson()`.

Fix: `AbortController` instead of a boolean flag, since payloads are large (~1MB, no workbox caching) and a flag only suppresses `setState`, not the download. Guard behaviour verified against the real endpoint; the end-to-end SPA-transition race itself was not staged in a booted browser.
