### PR TITLE
Compare service-day mask to "1", not truthiness

### DIFF
--- a/src/timetable.ts
+++ b/src/timetable.ts
@@ -48,7 +48,7 @@ export const isRouteAvaliable = (
   Object.entries(freq).forEach(([serviceId, startTimes]) => {
     try {
       serviceDayMap[serviceId].forEach((validDay, idx: number) => {
-        if (validDay === "1") {
+        if (Number(validDay) === 1) {
           Object.entries(startTimes).forEach(([startTime, endTime]) => {
             let time_a = getWeeklyTimestamp(idx, startTime);
             let time_b = getWeeklyTimestamp(

--- a/src/timetable.ts
+++ b/src/timetable.ts
@@ -48,7 +48,7 @@ export const isRouteAvaliable = (
   Object.entries(freq).forEach(([serviceId, startTimes]) => {
     try {
       serviceDayMap[serviceId].forEach((validDay, idx: number) => {
-        if (validDay) {
+        if (validDay === "1") {
           Object.entries(startTimes).forEach(([startTime, endTime]) => {
             let time_a = getWeeklyTimestamp(idx, startTime);
             let time_b = getWeeklyTimestamp(


### PR DESCRIPTION
`serviceDayMap` values are the strings `"0"`/`"1"`, so `if (validDay)` is true for both and the service-day mask is ignored entirely — a route is treated as running on days it does not run.

Verified against the live route DB on a Sunday for route `1+1+Central (Macao Ferry)+Happy Valley (Upper)` (both service ids exclude Sunday): before, `isRouteAvaliable = true` (wrong); after, `false`.

`hk-bus-eta`'s `getUpcomingFerry` has the same defect, filed separately: `https://github.com/hkbus/hk-bus-eta/issues/28`.

Used `Number(validDay) === 1` over `=== "1"` since the value is unenforced runtime JSON.
