### PR TITLE
a11y: fix contrast of highlighted ETA number (light mode)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -190,7 +190,9 @@ const getThemeTokens = (mode: PaletteMode, fontSize: number) => ({
             contrastText: "rgba(0, 0, 0, 0.12)",
           },
           warning: {
-            main: "#3285e3",
+            // shared accent; deepened from #3285e3 so the highlighted ETA text
+            // (home + route-eta) meets WCAG AA (4.5:1) on white — ~5.3:1
+            main: "#1b6bc5",
           },
           secondary: {
             main: "#000",


### PR DESCRIPTION
The highlighted next-arrival number uses the theme accent `warning.main` = `#3285e3`, which is ~3.75:1 on the white row background — below WCAG AA (1.4.3, 4.5:1). Deepen the light-mode token to `#1b6bc5` (~5.3:1). Fixing the token (not the component) covers both places that read it — home `SuccinctEtas` and the route-eta `TimeReport` — and keeps the components clean. Dark mode uses a separate token (`#fedb00` on black) and is unchanged.

<details><summary>Verified</summary>

axe on a local prod build (light): `color-contrast` **0** on home **and** route-eta (was failing on both); dark mode also 0. `#1b6bc5` on white = 5.31:1. `tsc`/`eslint`/`prettier` clean.
</details>
