### PR TITLE
a11y: add alt text to HKO weather-warning icons

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -225,6 +225,7 @@ const Header = () => {
             key={code}
             variant="square"
             src={WeatherIcons[code]}
+            alt={t("天氣警告")}
             sx={weatherImg}
           />
         ))}

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -26,6 +26,7 @@ const resources = {
       移除: "Remove",
       跳至主要內容: "Skip to main content",
       輸入巴士路線號碼搜尋: "Search by entering a bus route number",
+      天氣警告: "Weather warning",
       離線: "Offline",
       首頁: "Home",
       搜尋: "Search",


### PR DESCRIPTION
The HKO weather-warning icons in the header render as `<Avatar src=…>` with no `alt`, so a screen reader announces nothing (or the filename) while a warning is in effect (WCAG 1.1.1). Add `alt` via a new i18n key. No behaviour change.

<details><summary>Verified</summary>

axe on a local prod build (a warning was active): `image-alt` **0**; the `<img>` now reads "Weather warning". `tsc`/`eslint`/`prettier` (3.2.5 + 3.9.4) clean.
</details>
