### PR TITLE
a11y: let notice text flow instead of a clipped scroll region

### DIFF
--- a/src/components/layout/NoticeCard.tsx
+++ b/src/components/layout/NoticeCard.tsx
@@ -116,11 +116,7 @@ const NoticeCard = () => {
               <WarnIcon color="warning" />
               <Box onClick={handleClick(viewIdx)} sx={{ cursor: "pointer" }}>
                 {notice.content[language].map((v, idx) => (
-                  <Typography
-                    key={`_notice-${idx}`}
-                    variant="subtitle2"
-                    sx={{ height: "3.14em", overflowY: "auto" }}
-                  >
+                  <Typography key={`_notice-${idx}`} variant="subtitle2">
                     {v}
                   </Typography>
                 ))}


### PR DESCRIPTION
Each notice line was a fixed-height (`3.14em`) `overflowY: auto` box — a scrollable region with no keyboard access (WCAG 2.1.1). Remove the cap so the notice text flows and the card grows to fit its content; multi-notice paging via the existing tabs/swipe is unaffected. No behaviour change.

<details><summary>Verified</summary>

axe on a local prod build: home `scrollable-region-focusable` **2 → 1**; the removed node was the notice text box. (The residual 1 is a `react-swipeable-views` internal wrapper — separate, tracked as a distinct issue.) `tsc`/`eslint`/`prettier` (3.2.5 + 3.9.4) clean.
</details>
