### PR TITLE
Reject instead of hanging when route DB fetch fails

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -118,7 +118,7 @@ export const fetchDbFunc = async (
     }
     const updateTime = Date.now() + "";
     localStorage.setItem("updateTime", updateTime);
-    return new Promise((resolve_1) => {
+    return await new Promise((resolve_1, reject_1) => {
       const timerId = setTimeout(() => {
         if (!forceRenew) {
           const _cachedDb = loadStoredDb();
@@ -149,7 +149,8 @@ export const fetchDbFunc = async (
           localStorage.setItem("versionMd5", _md5);
           clearTimeout(timerId);
           resolve_1(ret);
-        });
+        })
+        .catch(reject_1);
     });
   } catch (e) {
     console.error("cannot get db", e);


### PR DESCRIPTION
When the ~8 MB route-DB fetch fails mid-transfer, `fetchDbFunc`'s promise never settles (no terminal `.catch`, executor takes no `reject`) — the app renders a blank page forever, no spinner, no retry.

<img src="https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets/issue83-after.png" width="300">

Fix: capture `reject` and add `.catch(reject_1)` so it falls into the existing empty-DB fallback. Repro: master hangs 47.9s (bodyLen 0); branch renders in 1.5s.
