### PR TITLE
Re-fetch route DB when the cached copy is missing

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -111,7 +111,7 @@ export const fetchDbFunc = async (
       needRenew = true;
     }
     if (!needRenew) {
-      const db = await loadStoredDb();
+      const db = await loadStoredDb().catch(() => null);
       if (isEtaDb(db)) {
         return db;
       }


### PR DESCRIPTION
If `localStorage.versionMd5` points at an IndexedDB record that's gone, the app returns an empty DB instead of re-fetching, and nothing clears `versionMd5` — so it repeats every launch (empty home, bookmarks, search).

`loadStoredDb()` rejects on a cache miss, escaping into `fetchDbFunc`'s outer `catch` instead of falling through to the network-fetch guard below it, which was written for exactly this case.

Verified: clear only IndexedDB, keep `versionMd5`, reload. master: 0 rows, no re-fetch. This branch: 36 rows, re-persisted.
