### PR TITLE
Keep the live route DB when a forced renew fails

### DIFF
--- a/src/context/DbContext.tsx
+++ b/src/context/DbContext.tsx
@@ -36,12 +36,14 @@ export const DbProvider = ({ initialDb, children }: DbProviderProps) => {
 
   const renewDb = useCallback(
     () =>
-      fetchDbFunc(true).then((db) =>
+      fetchDbFunc(true).then((db) => {
+        // a failed renew resolves an empty db; do not clobber live state
+        if (isEmptyObj(db.routeList)) return;
         setState((prev) => ({
           ...prev,
           db,
-        }))
-      ),
+        }));
+      }),
     []
   );
 


### PR DESCRIPTION
A forced DB renew that fails overwrites the live database with the empty one `fetchDbFunc`'s catch returns — tapping "update route database" while offline loses every route until reload.

`forceRenew` bypasses the `navigator.onLine` guard, so the fetch always runs and rejects offline; the catch's empty `DatabaseType` gets `setState`'d unconditionally. Fix: guard that write with the existing `isEmptyObj` check.

Verified: master goes 36 rows -> 0 after a failed renew; this branch stays 36, unpersisted, recoverable by reload.
