### PR TITLE
Prune stale route DB copies from IndexedDB

### DIFF
--- a/src/context/DbContext.tsx
+++ b/src/context/DbContext.tsx
@@ -76,6 +76,11 @@ export const DbProvider = ({ initialDb, children }: DbProviderProps) => {
           let idb = (event.target as IDBOpenDBRequest).result;
           let transaction = idb.transaction(["etadb"], "readwrite");
           let store = transaction.objectStore("etadb");
+          transaction.onabort = transaction.onerror = () => {
+            // the write did not land, force a re-fetch on next launch
+            localStorage.removeItem("versionMd5");
+          };
+          store.clear();
           store.put(db);
         };
       }, 0);


### PR DESCRIPTION
The `etadb` store is keyed on `versionMd5` and nothing ever removes an old record, so every published version leaves another full route-DB copy behind (~8.3 MB each). `DbRenewReminder` offers renew to everyone at 28 days, so even non-`autoRenew` users accumulate roughly a dozen copies a year.

Fix: `store.clear()` in the same readwrite transaction before the `put`, plus `onerror` handlers on the write.

Verified: seed a stale record alongside the live one, re-persist. master keeps both; this branch prunes to 1.
