### PR TITLE
Fix missing map label at high zoom level

### DIFF
--- a/src/components/map/maplibre/style.ts
+++ b/src/components/map/maplibre/style.ts
@@ -66,6 +66,7 @@ export const buildStyle = ({
       tiles: [labelTileUrl],
       tileSize: 256,
       attribution: LANDS_ATTRIBUTION,
+      maxzoom: 20,
     };
     style.sources[LABEL_SOURCE_ID] = rasterSource;
     style.layers.push({


### PR DESCRIPTION
CSDI Map Label provides tiles of zoom level up to 20. We attempt to load zoom level 21.
Left: Before; Right: After
<img width="1000" height="401" alt="1" src="https://github.com/user-attachments/assets/ed449187-9439-40e8-9799-735a225bd564" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Lands Department labels overlay by limiting its raster source to zoom level 20, ensuring more predictable map behavior at higher zoom levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->