### PR TITLE
Allow hosting from a sub-path via BASE_PATH

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ const App = () => {
       <ThemeProvider theme={theme}>
         <CacheProvider value={emotionCache}>
           <SearchContextProvider>
-            <Router>
+            <Router basename={import.meta.env.BASE_URL}>
               <Routes>
                 <Route path="/" element={<Navigate to={`/${language}`} />} />
                 <Route path="/:lang" element={<Root />}>

--- a/src/components/emotion/EmotionTabbar.tsx
+++ b/src/components/emotion/EmotionTabbar.tsx
@@ -38,7 +38,7 @@ const EmotionTabbar = () => {
         icon={
           <Box
             sx={{
-              backgroundImage: "url(/img/sympathy/tab-icon.png)",
+              backgroundImage: `url(${import.meta.env.BASE_URL}img/sympathy/tab-icon.png)`,
               backgroundPosition: "center",
               backgroundRepeat: "no-repeat",
               backgroundSize: "contain",

--- a/src/components/emotion/SympathyTab.tsx
+++ b/src/components/emotion/SympathyTab.tsx
@@ -18,9 +18,12 @@ const SympathyTab = () => {
 
   return (
     <Box sx={rootSx}>
-      <img src={`/img/sympathy/${imgIdx}.png`} style={{ width: "100%" }} />
       <img
-        src={`/img/sympathy/logo.png`}
+        src={`${import.meta.env.BASE_URL}img/sympathy/${imgIdx}.png`}
+        style={{ width: "100%" }}
+      />
+      <img
+        src={`${import.meta.env.BASE_URL}img/sympathy/logo.png`}
         style={{
           width: 56,
           height: 56,
@@ -38,14 +41,14 @@ const SympathyTab = () => {
         }}
       >
         <img
-          src={`/img/sympathy/text.png`}
+          src={`${import.meta.env.BASE_URL}img/sympathy/text.png`}
           style={{
             width: 231,
             height: 28,
           }}
         />
         <img
-          src={`/img/sympathy/button.png`}
+          src={`${import.meta.env.BASE_URL}img/sympathy/button.png`}
           style={{
             width: 28,
             height: 28,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -291,7 +291,7 @@ const appTitleSx: SxProps<Theme> = {
   backgroundImage: (t) =>
     t.palette.mode === "light"
       ? `url(${import.meta.env.BASE_URL}img/logo128.png)`
-      : "url(/img/dark-32.jpg)",
+      : `url(${import.meta.env.BASE_URL}img/dark-32.jpg)`,
   backgroundSize: "contain",
   width: 32,
   height: 32,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -290,7 +290,7 @@ const rootSx: SxProps<Theme> = {
 const appTitleSx: SxProps<Theme> = {
   backgroundImage: (t) =>
     t.palette.mode === "light"
-      ? "url(/img/logo128.png)"
+      ? `url(${import.meta.env.BASE_URL}img/logo128.png)`
       : "url(/img/dark-32.jpg)",
   backgroundSize: "contain",
   width: 32,

--- a/src/components/map/maplibre/BaseMap.tsx
+++ b/src/components/map/maplibre/BaseMap.tsx
@@ -152,7 +152,10 @@ const BaseMap = ({
       {children}
       {showLandsDepartmentBadge && (
         <Box sx={landsBadgeSx}>
-          <img src="/img/Lands_Department.svg" alt="Lands Department" />
+          <img
+            src={`${import.meta.env.BASE_URL}img/Lands_Department.svg`}
+            alt="Lands Department"
+          />
         </Box>
       )}
     </Map>

--- a/src/components/map/maplibre/RouteMap.tsx
+++ b/src/components/map/maplibre/RouteMap.tsx
@@ -469,10 +469,10 @@ const rootSx: SxProps<Theme> = {
       theme.palette.mode === "dark" ? "brightness(0.8)" : "none",
   },
   [`& .${classes.mtrMarker}`]: {
-    backgroundImage: `url(/img/mtr.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/mtr.svg)`,
   },
   [`& .${classes.gmbMarker}`]: {
-    backgroundImage: `url(/img/minibus.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/minibus.svg)`,
   },
   [`& .${classes.ctbMarker}`]: {
     backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_ctb.svg)`,
@@ -496,7 +496,7 @@ const rootSx: SxProps<Theme> = {
     filter: "grayscale(100%)",
   },
   [`& .self-center`]: {
-    backgroundImage: "url(/img/self.svg)",
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/self.svg)`,
     backgroundSize: "contain",
     backgroundRepeat: "no-repeat",
     backgroundPosition: "center",
@@ -504,7 +504,7 @@ const rootSx: SxProps<Theme> = {
     transformOrigin: "center",
   },
   ["& .mtr-exit"]: {
-    backgroundImage: `url(/img/HK_MTR_logo.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/HK_MTR_logo.svg)`,
   },
   ["& .mtr-exit-label"]: {
     background: "transparent",
@@ -512,7 +512,7 @@ const rootSx: SxProps<Theme> = {
     fontWeight: 600,
   },
   ["& .mtr-exit-barrier-free"]: {
-    backgroundImage: `url(/img/Wheelchair_symbol.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/Wheelchair_symbol.svg)`,
     backgroundSize: "12px 11px",
   },
 };

--- a/src/components/map/maplibre/RouteMap.tsx
+++ b/src/components/map/maplibre/RouteMap.tsx
@@ -475,19 +475,19 @@ const rootSx: SxProps<Theme> = {
     backgroundImage: `url(/img/minibus.svg)`,
   },
   [`& .${classes.ctbMarker}`]: {
-    backgroundImage: `url(/img/bus_ctb.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_ctb.svg)`,
   },
   [`& .${classes.jointlyMarker}`]: {
-    backgroundImage: `url(/img/bus_jointly.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_jointly.svg)`,
   },
   [`& .${classes.lrtfeederMarker}`]: {
-    backgroundImage: `url(/img/bus_lrtfeeder.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_lrtfeeder.svg)`,
   },
   [`& .${classes.nlbMarker}`]: {
-    backgroundImage: `url(/img/bus_nlb.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_nlb.svg)`,
   },
   [`& .${classes.kmbMarker}`]: {
-    backgroundImage: `url(/img/bus_kmb.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_kmb.svg)`,
   },
   [`& .${classes.active}`]: {
     animation: "blinker 1.5s infinite",

--- a/src/components/map/maplibre/RouteMap.tsx
+++ b/src/components/map/maplibre/RouteMap.tsx
@@ -455,10 +455,10 @@ const rootSx: SxProps<Theme> = {
     height: "35vh",
   },
   [`& .${classes.mtrMarker}`]: {
-    backgroundImage: `url(/img/mtr.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/mtr.svg)`,
   },
   [`& .${classes.gmbMarker}`]: {
-    backgroundImage: `url(/img/minibus.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/minibus.svg)`,
   },
   [`& .${classes.ctbMarker}`]: {
     backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_ctb.svg)`,
@@ -482,7 +482,7 @@ const rootSx: SxProps<Theme> = {
     filter: "grayscale(100%)",
   },
   [`& .self-center`]: {
-    backgroundImage: "url(/img/self.svg)",
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/self.svg)`,
     backgroundSize: "contain",
     backgroundRepeat: "no-repeat",
     backgroundPosition: "center",
@@ -490,7 +490,7 @@ const rootSx: SxProps<Theme> = {
     transformOrigin: "center",
   },
   ["& .mtr-exit"]: {
-    backgroundImage: `url(/img/HK_MTR_logo.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/HK_MTR_logo.svg)`,
   },
   ["& .mtr-exit-label"]: {
     background: "transparent",
@@ -498,7 +498,7 @@ const rootSx: SxProps<Theme> = {
     fontWeight: 600,
   },
   ["& .mtr-exit-barrier-free"]: {
-    backgroundImage: `url(/img/Wheelchair_symbol.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/Wheelchair_symbol.svg)`,
     backgroundSize: "12px 11px",
   },
 };

--- a/src/components/map/maplibre/RouteMap.tsx
+++ b/src/components/map/maplibre/RouteMap.tsx
@@ -461,19 +461,19 @@ const rootSx: SxProps<Theme> = {
     backgroundImage: `url(/img/minibus.svg)`,
   },
   [`& .${classes.ctbMarker}`]: {
-    backgroundImage: `url(/img/bus_ctb.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_ctb.svg)`,
   },
   [`& .${classes.jointlyMarker}`]: {
-    backgroundImage: `url(/img/bus_jointly.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_jointly.svg)`,
   },
   [`& .${classes.lrtfeederMarker}`]: {
-    backgroundImage: `url(/img/bus_lrtfeeder.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_lrtfeeder.svg)`,
   },
   [`& .${classes.nlbMarker}`]: {
-    backgroundImage: `url(/img/bus_nlb.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_nlb.svg)`,
   },
   [`& .${classes.kmbMarker}`]: {
-    backgroundImage: `url(/img/bus_kmb.svg)`,
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/bus_kmb.svg)`,
   },
   [`& .${classes.active}`]: {
     animation: "blinker 1.5s infinite",

--- a/src/components/map/maplibre/SearchMap.tsx
+++ b/src/components/map/maplibre/SearchMap.tsx
@@ -398,7 +398,7 @@ const rootSx: SxProps<Theme> = {
     filter: "grayscale(100%)",
   },
   [`& .self-center`]: {
-    backgroundImage: "url(/img/self.svg)",
+    backgroundImage: `url(${import.meta.env.BASE_URL}img/self.svg)`,
     backgroundSize: "contain",
     backgroundRepeat: "no-repeat",
     backgroundPosition: "center",

--- a/src/components/settings/InstallDialog.tsx
+++ b/src/components/settings/InstallDialog.tsx
@@ -41,7 +41,7 @@ const InstallDialog = ({ open, handleClose }: InstallDialogProps) => {
               }
             >
               <img
-                src="/img/google-play-badge.png"
+                src={`${import.meta.env.BASE_URL}img/google-play-badge.png`}
                 alt="Install via Google Play"
               />
             </Box>
@@ -53,7 +53,7 @@ const InstallDialog = ({ open, handleClose }: InstallDialogProps) => {
               }
             >
               <img
-                src="/img/app-store.svg"
+                src={`${import.meta.env.BASE_URL}img/app-store.svg`}
                 style={{ margin: "6%", width: "88%" }}
                 alt="Install via App Store"
               />

--- a/src/db.ts
+++ b/src/db.ts
@@ -100,7 +100,9 @@ export const fetchDbFunc = async (
 
   try {
     const [_schemaVersion, _md5] = await Promise.all([
-      fetch("/schema-version.txt").then((res) => res.text()),
+      fetch(`${import.meta.env.BASE_URL}schema-version.txt`).then((res) =>
+        res.text()
+      ),
       fetchEtaDbMd5(),
     ]);
     let needRenew = forceRenew;

--- a/src/pages/BookmarkedStopPage.tsx
+++ b/src/pages/BookmarkedStopPage.tsx
@@ -76,7 +76,7 @@ const BookmarkedStop = () => {
         bgcolor: bgColor,
         backgroundImage:
           stopTab === ""
-            ? `url(/img/stop-bookmark-guide-${colorMode}-${language}.png)`
+            ? `url(${import.meta.env.BASE_URL}img/stop-bookmark-guide-${colorMode}-${language}.png)`
             : "unset",
         opacity: stopTab === "" ? "0.8" : "unset",
       }}

--- a/src/pages/RouteSearchPage.tsx
+++ b/src/pages/RouteSearchPage.tsx
@@ -183,7 +183,9 @@ const RouteSearch = () => {
         const startLocation = locations.start
           ? locations.start.location
           : geolocation.current;
-        worker.current = new Worker("/search-worker.js");
+        worker.current = new Worker(
+          `${import.meta.env.BASE_URL}search-worker.js`
+        );
         worker.current.postMessage({
           routeList,
           stopList,

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -103,7 +103,9 @@ const Settings = () => {
   const updateApp = useCallback(() => {
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker
-        .register(`${import.meta.env.BASE_URL}sw.js`, { scope: "/" })
+        .register(`${import.meta.env.BASE_URL}sw.js`, {
+          scope: import.meta.env.BASE_URL,
+        })
         .then((registration) => {
           // registration worked
           registration.update();

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -103,7 +103,7 @@ const Settings = () => {
   const updateApp = useCallback(() => {
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker
-        .register("/sw.js", { scope: "/" })
+        .register(`${import.meta.env.BASE_URL}sw.js`, { scope: "/" })
         .then((registration) => {
           // registration worked
           registration.update();
@@ -457,7 +457,11 @@ const Settings = () => {
           }}
         >
           <ListItemAvatar>
-            <Avatar sx={iconSx} src="/img/logo128.png" alt="App Logo"></Avatar>
+            <Avatar
+              sx={iconSx}
+              src={`${import.meta.env.BASE_URL}img/logo128.png`}
+              alt="App Logo"
+            ></Avatar>
           </ListItemAvatar>
           <ListItemText primary={t("圖標來源")} secondary={"陳瓜 Chan Gua"} />
         </ListItemButton>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import react from "@vitejs/plugin-react-swc";
 import basicSsl from "@vitejs/plugin-basic-ssl";
 import { VitePWA, VitePWAOptions } from "vite-plugin-pwa";
 import eslint from "vite-plugin-eslint"
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 // https://vitejs.dev/config/
 
@@ -11,13 +13,15 @@ const mobile = !!/android|ios/.exec(process.env.TAURI_ENV_PLATFORM);
 export default defineConfig(({mode}: ConfigEnv) => {
   const env = loadEnv(mode, process.cwd(), "");
   return {
+    base: getBase(env),
     plugins: [
       react(), 
       eslint({
         
       }), 
       basicSsl(), 
-      VitePWA(getPwaOptions(env))
+      VitePWA(getPwaOptions(env)),
+      spaFallbackBase(getBase(env), "./build")
     ],
     server: {
       https: !mobile,
@@ -32,11 +36,35 @@ export default defineConfig(({mode}: ConfigEnv) => {
   }
 });
 
+// serve from a sub-path, e.g. BASE_PATH=/hkbus for user.github.io/hkbus
+const getBase = (env: Record<string, string>): string => {
+  const base = env.BASE_PATH || "/";
+  return base.endsWith("/") ? base : `${base}/`;
+};
+
+// public/404.html ships verbatim, so align its spa-github-pages segment
+// count with the base once the build is written
+const spaFallbackBase = (base: string, outDir: string) => ({
+  name: "spa-fallback-base",
+  closeBundle() {
+    const file = resolve(outDir, "404.html");
+    writeFileSync(file, readFileSync(file, "utf-8").replace(
+      /var pathSegmentsToKeep = \d+;/,
+      `var pathSegmentsToKeep = ${base.split("/").filter(Boolean).length};`));
+  },
+});
+
 const getPwaOptions = (env: Record<string, string>): Partial<VitePWAOptions> => {
   const mapUrlPatternFunc = `(({url}) => url.origin.includes("${env.VITE_OSM_PROVIDER_HOST}"))`;
+  const base = getBase(env);
+  // inlined as source because workbox serialises these into sw.js
+  const prefixUrlPatternFunc = (...paths: string[]) =>
+    `(({url}) => url.origin === self.location.origin && (${paths
+      .map((p) => `url.pathname.startsWith("${base}${p}")`)
+      .join(" || ")}))`;
   return {
     mode: "production",
-    base: "/",
+    base,
     manifest: {
       short_name: "巴士預報",
       name: "巴士到站預報 App",
@@ -77,9 +105,8 @@ const getPwaOptions = (env: Record<string, string>): Partial<VitePWAOptions> => 
         // for lazy caching anything
         // reference to https://vite-pwa-org.netlify.app/workbox/generate-sw.html#cache-external-resources 
         {
-          urlPattern: ({url}) => (
-            url.origin === self.location.origin && url.pathname.startsWith("/assets")
-          ),
+          urlPattern: new Function(
+            'return ' + prefixUrlPatternFunc("assets"))(),
           handler: "CacheFirst",
           options: {
             cacheName: "app-runtime",
@@ -89,10 +116,8 @@ const getPwaOptions = (env: Record<string, string>): Partial<VitePWAOptions> => 
           }
         },
         {
-          urlPattern: ({ url }) =>
-            url.origin === self.location.origin &&
-            (url.pathname.startsWith("/zh/route/") ||
-              url.pathname.startsWith("/en/route/")),
+          urlPattern: new Function(
+            'return ' + prefixUrlPatternFunc("zh/route/", "en/route/"))(),
           handler: "StaleWhileRevalidate",
           options: {
             cacheName: "app-runtime-public",
@@ -106,9 +131,8 @@ const getPwaOptions = (env: Record<string, string>): Partial<VitePWAOptions> => 
           }
         },
         {
-          urlPattern: ({ url }) =>
-            url.origin === self.location.origin &&
-            (url.pathname.startsWith("/fonts/") || url.pathname.startsWith("/img/")),
+          urlPattern: new Function(
+            'return ' + prefixUrlPatternFunc("fonts/", "img/"))(),
           handler: "CacheFirst",
           options: {
             cacheName: "font-and-asset",


### PR DESCRIPTION
Addresses #303 — hosting a custom instance at `<user>.github.io/<project>` without a custom domain.

`BASE_PATH=/repo-name yarn build` now produces a working sub-path build; the default output is unchanged, verified byte-for-byte. Required changes beyond Vite's `base`: PWA plugin `base`, 3 root-anchored workbox `urlPattern`s, a `<Router basename>` (none existed), `404.html` segment count, and 17 root-absolute path string literals across 8 files that Vite cannot rewrite.

Verified in a browser (fresh port, real 404-redirect chain): deep links, assets and service-worker scope all resolve correctly at both `/` and `/hkbus/`.
