### PR TITLE
Show a GMB headway range instead of only its lower bound

### DIFF
--- a/src/components/route-eta/timetableDrawer/TimeTable.tsx
+++ b/src/components/route-eta/timetableDrawer/TimeTable.tsx
@@ -60,6 +60,7 @@ const TimeTable = ({ routeId }: TimeTableProps) => {
                     {details ? (
                       <Typography variant="body1">
                         {parseInt(details[1], 10) / 60}
+                        {details[2] ? `-${parseInt(details[2], 10) / 60}` : ""}
                         {t("分鐘")}
                       </Typography>
                     ) : (
@@ -178,7 +179,7 @@ const isMatchServiceId = (serviceId: string, isHoliday: boolean): boolean => {
 
 const isCurrentTimeslot = (
   start: string,
-  details: [string, string] | null,
+  details: [string, string, string?] | null,
   serviceId: string,
   isHoliday: boolean
 ): boolean => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -317,7 +317,7 @@ export const setSeoRouteFeature = ({
                 .map(
                   ([start, details]) =>
                     "<li>" +
-                    `${start} ${details ? `- ${details[0]}    ${parseInt(details[1], 10) / 60}${t("分鐘")}` : ""}` +
+                    `${start} ${details ? `- ${details[0]}    ${parseInt(details[1], 10) / 60}${details[2] ? `-${parseInt(details[2], 10) / 60}` : ""}${t("分鐘")}` : ""}` +
                     "</li>"
                 )
                 .join("") +


### PR DESCRIPTION
Draft — blocked on an npm release of `hk-bus-eta`. Part 3 of 3 for `https://github.com/hkbus/hk-bus-crawling/issues/61`.

Renders a GMB headway range as `7-10分鐘` instead of `7分鐘`, in the timetable drawer and JSON-LD FAQ data.

Can't go green until `https://github.com/hkbus/hk-bus-eta/pull/31` merges and publishes to npm; this PR then bumps the dependency + lockfile. `tsc` fails against the currently-published 2-tuple `Freq` type (`vite build` alone doesn't catch it — esbuild skips type-checking). Left as draft rather than parking a red build.
