### PR TITLE
Explain the empty route board when filtering is on

### DIFF
--- a/src/components/route-board/SwipeableRoutesBoard.tsx
+++ b/src/components/route-board/SwipeableRoutesBoard.tsx
@@ -10,7 +10,7 @@ import { FixedSizeList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
 import memorize from "memoize-one";
 import { Trans, useTranslation } from "react-i18next";
-import { Box, SxProps, Theme, Typography } from "@mui/material";
+import { Box, Link, SxProps, Theme, Typography } from "@mui/material";
 
 import AppContext from "../../context/AppContext";
 import { isHoliday, isRouteAvaliable } from "../../timetable";
@@ -159,9 +159,10 @@ const SwipeableRoutesBoard = ({
                             i18nKey="route-filter-may-hide-result"
                             components={{
                               TapHereLink: (
-                                <Typography
-                                  variant="body1"
-                                  component="span"
+                                <Link
+                                  component="button"
+                                  type="button"
+                                  color="inherit"
                                   sx={clickableLinkSx}
                                   onClick={() => toggleRouteFilter()}
                                 />
@@ -194,9 +195,10 @@ const SwipeableRoutesBoard = ({
                         i18nKey="tap-here-to-search-all-routes"
                         components={{
                           TapHereLink: (
-                            <Typography
-                              variant="h6"
-                              component="span"
+                            <Link
+                              component="button"
+                              type="button"
+                              color="inherit"
                               sx={clickableLinkSx}
                               onClick={() => onChangeTab("all")}
                             />

--- a/src/components/route-board/SwipeableRoutesBoard.tsx
+++ b/src/components/route-board/SwipeableRoutesBoard.tsx
@@ -32,6 +32,7 @@ const SwipeableRoutesBoard = ({
   const {
     searchRoute,
     isRouteFilter,
+    toggleRouteFilter,
     busSortOrder,
     routeSearchHistory,
     vibrateDuration,
@@ -152,6 +153,23 @@ const SwipeableRoutesBoard = ({
                       <Typography variant="body1">
                         {t("suggest-update-database")}
                       </Typography>
+                      {isRouteFilter && (
+                        <Typography variant="body1" textAlign="center" px={2}>
+                          <Trans
+                            i18nKey="route-filter-may-hide-result"
+                            components={{
+                              TapHereLink: (
+                                <Typography
+                                  variant="body1"
+                                  component="span"
+                                  sx={clickableLinkSx}
+                                  onClick={() => toggleRouteFilter()}
+                                />
+                              ),
+                            }}
+                          />
+                        </Typography>
+                      )}
                     </>
                   ) : (
                     <Box display="flex" alignItems="center" gap={2}>
@@ -194,7 +212,16 @@ const SwipeableRoutesBoard = ({
         )}
       </React.Fragment>
     ),
-    [itemHeight, coItemDataList, searchRoute, t, availableBoardTab, onChangeTab]
+    [
+      itemHeight,
+      coItemDataList,
+      searchRoute,
+      t,
+      availableBoardTab,
+      onChangeTab,
+      isRouteFilter,
+      toggleRouteFilter,
+    ]
   );
 
   return useMemo(
@@ -258,7 +285,7 @@ const prerenderListSx: SxProps<Theme> = {
 };
 
 const noResultSx: SxProps<Theme> = {
-  height: "120px",
+  minHeight: "120px",
   display: "flex",
   flexDirection: "column",
   alignItems: "center",

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -156,6 +156,8 @@ const resources = {
       "no-recent-search": "No Record",
       "tap-here-to-search-all-routes":
         "<TapHereLink>Tap here</TapHereLink> to search all routes",
+      "route-filter-may-hide-result":
+        "Route filtering is ON, showing ONLY operating routes. <TapHereLink>Tap here</TapHereLink> to show ALL routes.",
       對頭線: "REV",
       附近未有任何路線: "No available routes nearby",
       未有收藏路線: "No starred routes",
@@ -259,6 +261,8 @@ const resources = {
       "no-recent-search": "沒有記錄",
       "tap-here-to-search-all-routes":
         "<TapHereLink>按此</TapHereLink>以搜尋「全部」路綫",
+      "route-filter-may-hide-result":
+        "路線篩選已開啟，只顯示現時路線。<TapHereLink>按此</TapHereLink>顯示所有路線。",
       "Source code": "原始碼",
       "We'd like to set analytics cookies that help us improve hkbus.app by measuring how you use it.":
         "我們希望設置 cookie，了解你如何使用 hkbus.app 來幫助我們改進。",


### PR DESCRIPTION
When `isRouteFilter` is on, an empty route-board result looks identical to "route does not exist". Two users in the community Telegram group independently reported 807 and K58 as missing — both times the filter was silently on.

Adds one line to the empty state explaining the filter, plus a one-tap toggle-off, mirroring the existing "tap here to search all routes" pattern.

![after](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets-filterhint/after-en.png)

+33/−2, two files. Verified in a real browser on route K58: tap flips `isRouteFilter` and K58 appears.
