### PR TITLE
Fix MTR route lines: split routeId on '+' not '-' for waypoint filename

### DIFF
--- a/src/hooks/useRoutePath.tsx
+++ b/src/hooks/useRoutePath.tsx
@@ -26,7 +26,7 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
         bound[co[0]] === "I" ? "I" : "O" // handling for pseudo circular route
       }.json`;
     } else if (co.includes("mtr")) {
-      waypointsFile = `${routeId.split("-")[0].toLowerCase()}.json`;
+      waypointsFile = `${routeId.split("+")[0].toLowerCase()}.json`;
     } else if (route && co.includes("lightRail")) {
       // For light rail map
       waypointsFile = `${route}${dest.en.includes("Circular") ? "" : bound[co[0]] === "I" ? "_I" : "_O"}.json`;


### PR DESCRIPTION
## Problem

All 10 MTR line maps draw straight-line fallback polylines instead of real alignments. Both directions of every MTR line are affected.

`routeList` keys are `+`-separated (e.g. `AEL+1+Hong Kong+AsiaWorld-Expo`), but the MTR branch of `useRoutePath.tsx` splits on `-`:

```js
waypointsFile = `${routeId.split("-")[0].toLowerCase()}.json`;
```

This produces garbage filenames that always 404:

| routeList key | broken filename | correct filename |
|---|---|---|
| `AEL+1+Hong Kong+AsiaWorld-Expo` | `ael+1+hong kong+asiaworld.json` | `ael.json` |
| `EAL+1+Admiralty+Lo Wu` | `eal+1+admiralty+lo wu.json` | `eal.json` |

Keys with no hyphen at all return the entire key; keys with a hyphen in the station name (e.g. `AsiaWorld-Expo`) truncate at the wrong point. **0 of 24 MTR entries resolve.**

## Fix

One character — split on `+` instead of `-`:

```diff
-      waypointsFile = `${routeId.split("-")[0].toLowerCase()}.json`;
+      waypointsFile = `${routeId.split("+")[0].toLowerCase()}.json`;
```

All 24 MTR route-dirs now resolve to the correct 10 published files (`ael.json`, `drl.json`, `eal.json`, `isl.json`, `ktl.json`, `sil.json`, `tcl.json`, `tkl.json`, `tml.json`, `twl.json`). All 10 confirmed HTTP 200 on `hkbus.github.io/route-waypoints/`.

## Verification

- Replayed against live `routeFareList.min.json`: 0/24 → **24/24** resolve
- Probed all 10 published MTR waypoint files: all **HTTP 200**
- `tsc --noEmit` and `eslint` pass clean
- Not browser-verified in this PR (service worker cache caveat); the data-side replay is deterministic

Fixes hkbus/hk-independent-bus-eta#17 (filed by the hkbus-telegram-miner loop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected waypoint file selection for MTR routes with route IDs containing `+`, ensuring the appropriate route data is loaded.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->