### PR TITLE
Fetch ferry route waypoints by route code

### DIFF
--- a/src/hooks/useRoutePath.tsx
+++ b/src/hooks/useRoutePath.tsx
@@ -1,6 +1,7 @@
 import { StopListEntry } from "hk-bus-eta";
 import { useContext, useEffect, useState } from "react";
 import DbContext from "../context/DbContext";
+import { coToType } from "../utils";
 
 interface GeoJsonType extends GeoJSON.GeoJsonObject {
   features?: Array<{
@@ -21,9 +22,8 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
 
   useEffect(() => {
     let waypointsFile = "";
-    const ferryOperators = ["fortuneferry", "sunferry", "hkkf"];
-    if (co.some((c) => ferryOperators.includes(c))) {
-      // Ferry routes: files are named by route code, no direction suffix
+    if (co.some((c) => coToType[c] === "ferry")) {
+      // ferry files are named by route code, with no direction suffix
       waypointsFile = `${route}.json`;
     } else if (gtfsId) {
       waypointsFile = `${gtfsId}-${

--- a/src/hooks/useRoutePath.tsx
+++ b/src/hooks/useRoutePath.tsx
@@ -21,7 +21,11 @@ export const useRoutePath = (routeId: string, stops: StopListEntry[]) => {
 
   useEffect(() => {
     let waypointsFile = "";
-    if (gtfsId) {
+    const ferryOperators = ["fortuneferry", "sunferry", "hkkf"];
+    if (co.some((c) => ferryOperators.includes(c))) {
+      // Ferry routes: files are named by route code, no direction suffix
+      waypointsFile = `${route}.json`;
+    } else if (gtfsId) {
       waypointsFile = `${gtfsId}-${
         bound[co[0]] === "I" ? "I" : "O" // handling for pseudo circular route
       }.json`;


### PR DESCRIPTION
Ferry routes (KF1, 7025, etc.) draw a straight line between piers instead of the real curved geometry.

`useRoutePath.tsx` has branches for bus/MTR/lightRail but none for ferry, so ferry routes fall through to the `gtfsId` branch and fetch `${gtfsId}-I.json`, while route-waypoints stores ferry files as `${route}.json` (no direction suffix).

Fix: add a ferry branch, keyed on the existing `coToType` map, fetching `${route}.json`. All 29 ferry routes now resolve (verified against live route-waypoints data).

Fixes `evnchn/hkbus-telegram-miner#4` (ferry bucket).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ferry route detection when selecting route-code waypoint files.
  - Ferry routes are now handled consistently across supported operators.
  - Non-ferry route file selection remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->