### PR TITLE
Add timetable source disclaimer

### DIFF
--- a/src/components/route-eta/timetableDrawer/TimeTable.tsx
+++ b/src/components/route-eta/timetableDrawer/TimeTable.tsx
@@ -73,6 +73,10 @@ const TimeTable = ({ routeId }: TimeTableProps) => {
       <Divider sx={{ width: "80%", my: 2 }} />
       <Box sx={{ mb: 6 }}>
         <RouteOffiicalUrlBtn routeId={routeId} />
+        {/* disclaimer: government open-data timetables can lag operator changes */}
+        <Typography variant="caption" sx={disclaimerSx}>
+          {t("timetable-disclaimer-text")}
+        </Typography>
       </Box>
       <Box sx={{ paddingBottom: "env(safe-area-inset-bottom)" }} />
     </>
@@ -149,6 +153,12 @@ const ServiceMaps: Record<
 const entriesSx: SxProps<Theme> = {
   flexDirection: "column",
   alignItems: "flex-start",
+};
+
+const disclaimerSx: SxProps<Theme> = {
+  display: "block",
+  mt: 1,
+  color: (theme) => theme.palette.text.secondary,
 };
 
 const freqContainerSx: SxProps<Theme> = {

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -6,7 +6,7 @@ const resources = {
       "bad-weather-link": "https://www.td.gov.hk/en/special_news/spnews.htm",
       "db-renew-text": "Tap to fetch revised route info",
       "timetable-disclaimer-text":
-        "Timetable data from the government open-data platform may lag behind operator changes. For the latest timetable, please check the operator's website.",
+        "Timetable data from the government open-data platform may lag behind operator changes. For the latest timetable, please check the operator's or Transport Department's website.",
       "巴士到站預報 App （免費無廣告）": "HK Bus ETA App (Free and Ad-free)",
       "巴士到站預報 App": "HK Bus ETA App",
       巴士到站預報: "HK BUS ETA",
@@ -224,7 +224,7 @@ const resources = {
       "bad-weather-link": "https://www.td.gov.hk/tc/special_news/spnews.htm",
       "db-renew-text": "路線資料已作修訂，請按此處更新",
       "timetable-disclaimer-text":
-        "政府開放數據平台的時間表更新可能有滯後，最新時間表請參閱巴士公司網頁",
+        "政府開放數據平台的時間表更新可能有滯後，最新時間表請參閱營辦商或運輸署網頁",
       kmb: "九巴",
       ctb: "城巴",
       nlb: "嶼巴",

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -5,6 +5,8 @@ const resources = {
         "Services may be impacted by bad weather. Data displayed below might not be accurate. Check here for official announcements.",
       "bad-weather-link": "https://www.td.gov.hk/en/special_news/spnews.htm",
       "db-renew-text": "Tap to fetch revised route info",
+      "timetable-disclaimer-text":
+        "Timetable data from the government open-data platform may lag behind operator changes. For the latest timetable, please check the operator's website.",
       "巴士到站預報 App （免費無廣告）": "HK Bus ETA App (Free and Ad-free)",
       "巴士到站預報 App": "HK Bus ETA App",
       巴士到站預報: "HK BUS ETA",
@@ -221,6 +223,8 @@ const resources = {
         "公共交通及班次或受惡劣天氣影響，以下資料未必反映最新狀況。按此查看官方公佈。",
       "bad-weather-link": "https://www.td.gov.hk/tc/special_news/spnews.htm",
       "db-renew-text": "路線資料已作修訂，請按此處更新",
+      "timetable-disclaimer-text":
+        "政府開放數據平台的時間表更新可能有滯後，最新時間表請參閱巴士公司網頁",
       kmb: "九巴",
       ctb: "城巴",
       nlb: "嶼巴",


### PR DESCRIPTION
When an operator changes a route, the government open-data timetable can lag behind, leaving the app's timetable stale or absent with no signal to the user. Two live cases in August 2026 (CTB 770 broken 18 days; CTB 50M inbound still unmatched).

A community member proposed a disclaimer next to the operator link; this PR adds it. +14/−0, two files: a caption below the operator-link button, plus en/zh translation keys.

en: "Timetable data from the government open-data platform may lag behind operator changes. For the latest timetable, please check the operator's or Transport Department's website."
