### PR TITLE
fix: show ad-blocker warning when KMB ETA fetch is blocked

### DIFF
--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -53,10 +53,7 @@ const TimeReport = ({
     [etas]
   );
   const hasFetchError = fetchErrorEtas.length > 0;
-  const validEtas = useMemo(
-    () => (etas ?? []).filter((e) => e.eta),
-    [etas]
-  );
+  const validEtas = useMemo(() => (etas ?? []).filter((e) => e.eta), [etas]);
   const hasValidEtas = validEtas.length > 0;
 
   const noScheduleRemark = useMemo(() => {
@@ -118,8 +115,7 @@ const TimeReport = ({
           <WarningIcon
             sx={{ fontSize: 16, mr: 0.5, verticalAlign: "text-bottom" }}
           />
-          {fetchErrorEtas[0].remark?.[language] ??
-            t("ETA 請求被封鎖")}
+          {fetchErrorEtas[0].remark?.[language] ?? t("ETA 請求被封鎖")}
         </Typography>
       )}
       {hasFetchError && hasValidEtas && (

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -53,7 +53,11 @@ const TimeReport = ({
     [etas]
   );
   const hasFetchError = fetchErrorEtas.length > 0;
-  const hasValidEtas = etas !== null && etas.some((e) => e.eta);
+  const validEtas = useMemo(
+    () => (etas ?? []).filter((e) => e.eta),
+    [etas]
+  );
+  const hasValidEtas = validEtas.length > 0;
 
   const noScheduleRemark = useMemo(() => {
     let isEndOfTrainLine = false;
@@ -114,7 +118,8 @@ const TimeReport = ({
           <WarningIcon
             sx={{ fontSize: 16, mr: 0.5, verticalAlign: "text-bottom" }}
           />
-          {fetchErrorEtas[0].remark[language]}
+          {fetchErrorEtas[0].remark?.[language] ??
+            t("ETA 請求被封鎖")}
         </Typography>
       )}
       {hasFetchError && hasValidEtas && (
@@ -129,9 +134,8 @@ const TimeReport = ({
         </Typography>
       )}
       {noScheduleRemark}
-      {etas.length > 0 &&
-        etas.every((e) => e.eta) &&
-        etas.map((eta, idx) => (
+      {validEtas.length > 0 &&
+        validEtas.map((eta, idx) => (
           <EtaLine
             key={`route-${idx}`}
             eta={eta}

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -1,5 +1,6 @@
 import { useContext, useMemo } from "react";
 import { Box, SxProps, Theme, Typography } from "@mui/material";
+import { Warning as WarningIcon } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 import AppContext from "../../context/AppContext";
 import { useEtas } from "../../hooks/useEtas";
@@ -47,6 +48,13 @@ const TimeReport = ({
     [routeList, routeId, stopList]
   );
 
+  const fetchErrorEtas = useMemo(
+    () => (etas ?? []).filter((e) => e.fetchError),
+    [etas]
+  );
+  const hasFetchError = fetchErrorEtas.length > 0;
+  const hasValidEtas = etas !== null && etas.some((e) => e.eta);
+
   const noScheduleRemark = useMemo(() => {
     let isEndOfTrainLine = false;
     if (co[0] === "mtr") {
@@ -58,6 +66,10 @@ const TimeReport = ({
     }
 
     if (etas === null) {
+      return null;
+    }
+
+    if (hasFetchError) {
       return null;
     }
 
@@ -73,7 +85,7 @@ const TimeReport = ({
       return t("未有班次資料");
     }
     return null;
-  }, [etas, co, stops, stopId, t, language]);
+  }, [etas, co, stops, stopId, t, language, hasFetchError]);
 
   const liveProps = announce
     ? { role: "status" as const, "aria-live": "polite" as const }
@@ -92,6 +104,24 @@ const TimeReport = ({
       {showStopName && (
         <Typography variant="caption">
           {stopList[stopId].name[language]}
+        </Typography>
+      )}
+      {hasFetchError && !hasValidEtas && (
+        <Typography
+          variant="body2"
+          sx={{ color: (theme) => theme.palette.warning.main }}
+        >
+          <WarningIcon sx={{ fontSize: 16, mr: 0.5, verticalAlign: "text-bottom" }} />
+          {fetchErrorEtas[0].remark[language]}
+        </Typography>
+      )}
+      {hasFetchError && hasValidEtas && (
+        <Typography
+          variant="caption"
+          sx={{ color: (theme) => theme.palette.warning.main }}
+        >
+          <WarningIcon sx={{ fontSize: 14, mr: 0.5, verticalAlign: "text-bottom" }} />
+          {t("部分營運商 ETA 被封鎖")}
         </Typography>
       )}
       {noScheduleRemark}

--- a/src/components/route-eta/TimeReport.tsx
+++ b/src/components/route-eta/TimeReport.tsx
@@ -111,7 +111,9 @@ const TimeReport = ({
           variant="body2"
           sx={{ color: (theme) => theme.palette.warning.main }}
         >
-          <WarningIcon sx={{ fontSize: 16, mr: 0.5, verticalAlign: "text-bottom" }} />
+          <WarningIcon
+            sx={{ fontSize: 16, mr: 0.5, verticalAlign: "text-bottom" }}
+          />
           {fetchErrorEtas[0].remark[language]}
         </Typography>
       )}
@@ -120,7 +122,9 @@ const TimeReport = ({
           variant="caption"
           sx={{ color: (theme) => theme.palette.warning.main }}
         >
-          <WarningIcon sx={{ fontSize: 14, mr: 0.5, verticalAlign: "text-bottom" }} />
+          <WarningIcon
+            sx={{ fontSize: 14, mr: 0.5, verticalAlign: "text-bottom" }}
+          />
           {t("部分營運商 ETA 被封鎖")}
         </Typography>
       )}

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -213,6 +213,7 @@ const resources = {
       "支援 WearOS 及 WatchOS 平台": "Support WearOS & WatchOS",
       地圖資源: "Map Resources",
       同感心: "Empathy",
+      "部分營運商 ETA 被封鎖": "Some operators' ETAs are blocked",
     },
   },
   zh: {


### PR DESCRIPTION
When an adblocker blocks the KMB ETA endpoint, the app shows "未有班次資料" (no info) — same message as "no buses running". Users read this as an app bug.

This PR detects the `fetchError` flag from the companion `hk-bus-eta` PR and shows a warning with a diagnostic hint instead: full block shows "ETA request blocked — check your ad blocker"; partial block shows a subtler caption above the valid ETAs.

Requires the companion hk-bus-eta PR (adds `fetchError`) merged/released first.

Fixes `evnchn/hkbus-telegram-miner#10`.
