### PR TITLE
Sun-side seat hint: a colour stroke down each stop row

### DIFF
--- a/src/components/route-eta/StopAccordion.tsx
+++ b/src/components/route-eta/StopAccordion.tsx
@@ -39,10 +39,7 @@ interface StopAccordionProps {
   onShareClick: () => void;
   onStopInfoClick: () => void;
   onSummaryClick: (idx: number, expand: boolean) => void;
-  /**
-   * Which side of the bus the sun falls on over the leg leaving this
-   * stop: −1 hard left … +1 hard right. Undefined after dark.
-   */
+  /** −1 hard left … +1 hard right; undefined after dark. */
   sunSide?: number;
 }
 
@@ -239,7 +236,6 @@ const accordionSx: SxProps<Theme> = {
 };
 
 const accordionSummarySx: SxProps<Theme> = {
-  // Anchors the sun mark to the row.
   position: "relative",
   backgroundColor: (theme) =>
     theme.palette.mode === "dark"

--- a/src/components/route-eta/StopAccordion.tsx
+++ b/src/components/route-eta/StopAccordion.tsx
@@ -20,7 +20,9 @@ import {
   PushPinOutlined as PushPinOutlinedIcon,
 } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
+import { visuallyHidden } from "@mui/utils";
 import { getJoyYouFare, toProperCase, triggerShare } from "../../utils";
+import SunSideMark, { sunSideLabel } from "./SunSideMark";
 import TimeReport from "./TimeReport";
 import ReactNativeContext from "../../context/ReactNativeContext";
 import useLanguage from "../../hooks/useTranslation";
@@ -37,6 +39,11 @@ interface StopAccordionProps {
   onShareClick: () => void;
   onStopInfoClick: () => void;
   onSummaryClick: (idx: number, expand: boolean) => void;
+  /**
+   * Which side of the bus the sun falls on over the leg leaving this
+   * stop: −1 hard left … +1 hard right. Undefined after dark.
+   */
+  sunSide?: number;
 }
 
 const StopAccordion = React.forwardRef<HTMLDivElement, StopAccordionProps>(
@@ -50,6 +57,7 @@ const StopAccordion = React.forwardRef<HTMLDivElement, StopAccordionProps>(
       onShareClick,
       onSummaryClick,
       onStopInfoClick,
+      sunSide,
     } = props;
     const {
       AppTitle,
@@ -79,6 +87,8 @@ const StopAccordion = React.forwardRef<HTMLDivElement, StopAccordionProps>(
       () => getJoyYouFare(route, co, fares, idx),
       [co, fares, idx, route]
     );
+
+    const sunLabel = sunSideLabel(sunSide);
 
     const handleShareClick = useCallback(() => {
       triggerShare(
@@ -124,6 +134,12 @@ const StopAccordion = React.forwardRef<HTMLDivElement, StopAccordionProps>(
           <Typography component="h3" variant="body1" sx={{ fontWeight: 700 }}>
             {idx + 1}. {toProperCase(stop.name[language])}
           </Typography>
+          {sunLabel !== null && (
+            <Typography variant="body2" style={visuallyHidden}>
+              {t(sunLabel)}
+            </Typography>
+          )}
+          <SunSideMark value={sunSide} />
           <Typography variant="body2">
             {fares && fares[idx] ? t("車費") + ": $" + fares[idx] : ""}
             {faresHoliday && faresHoliday[idx]
@@ -223,6 +239,8 @@ const accordionSx: SxProps<Theme> = {
 };
 
 const accordionSummarySx: SxProps<Theme> = {
+  // Anchors the sun mark to the row.
+  position: "relative",
   backgroundColor: (theme) =>
     theme.palette.mode === "dark"
       ? theme.palette.background.default

--- a/src/components/route-eta/StopAccordionList.tsx
+++ b/src/components/route-eta/StopAccordionList.tsx
@@ -38,8 +38,9 @@ const StopAccordions = ({
   } = useContext(DbContext);
 
   const stopLocations = useMemo(
-    () => stopIds.map((stopId) => stopList[stopId].location),
-    [stopIds, stopList]
+    () =>
+      sunSideHint ? stopIds.map((stopId) => stopList[stopId].location) : [],
+    [sunSideHint, stopIds, stopList]
   );
   const sun = useSunExposure(stopLocations, sunSideHint);
   const sunriseAt = useNextSunrise(stopLocations[0], sunSideHint);

--- a/src/components/route-eta/StopAccordionList.tsx
+++ b/src/components/route-eta/StopAccordionList.tsx
@@ -114,10 +114,7 @@ const rootSx: SxProps<Theme> = {
   overflowY: "scroll",
 };
 
-/**
- * Stands in after dark. Says when the hint will next mean something,
- * rather than leaving a blank that reads as a fault.
- */
+// After dark, says when the hint will next mean something.
 const asleepSx: SxProps<Theme> = {
   px: 1.5,
   py: 1,

--- a/src/components/route-eta/StopAccordionList.tsx
+++ b/src/components/route-eta/StopAccordionList.tsx
@@ -1,8 +1,18 @@
-import { useEffect, useState, useRef, useCallback } from "react";
+import {
+  useEffect,
+  useState,
+  useRef,
+  useCallback,
+  useContext,
+  useMemo,
+} from "react";
 import { Box, Snackbar, SxProps, Theme } from "@mui/material";
 import type { RouteListEntry } from "hk-bus-eta";
 import StopAccordion from "./StopAccordion";
 import { useTranslation } from "react-i18next";
+import AppContext from "../../context/AppContext";
+import DbContext from "../../context/DbContext";
+import { useNextSunrise, useSunExposure } from "../../hooks/useSunExposure";
 
 interface StopAccordionsProps {
   routeId: string;
@@ -22,6 +32,17 @@ const StopAccordions = ({
   const accordionRef = useRef<HTMLDivElement[]>([]);
   const [isCopied, setIsCopied] = useState<boolean>(false);
   const { t } = useTranslation();
+  const { sunSideHint } = useContext(AppContext);
+  const {
+    db: { stopList },
+  } = useContext(DbContext);
+
+  const stopLocations = useMemo(
+    () => stopIds.map((stopId) => stopList[stopId].location),
+    [stopIds, stopList]
+  );
+  const sun = useSunExposure(stopLocations, sunSideHint);
+  const sunriseAt = useNextSunrise(stopLocations[0], sunSideHint);
 
   useEffect(() => {
     // scroll to specific bus stop
@@ -49,6 +70,16 @@ const StopAccordions = ({
 
   return (
     <Box sx={rootSx}>
+      {sunriseAt !== null && (
+        <Box sx={asleepSx}>
+          {t("太陽已下山")} · {t("日出")}{" "}
+          {sunriseAt.toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+          })}
+        </Box>
+      )}
       {stopIds.map((stopId, idx) => (
         <StopAccordion
           routeId={routeId}
@@ -58,6 +89,7 @@ const StopAccordions = ({
           onShareClick={() => setIsCopied(true)}
           onSummaryClick={handleChange}
           onStopInfoClick={onStopInfo}
+          sunSide={sun?.sides[idx]}
           key={"stop-" + idx}
           ref={handleRef(idx)}
         />
@@ -79,4 +111,16 @@ export default StopAccordions;
 
 const rootSx: SxProps<Theme> = {
   overflowY: "scroll",
+};
+
+/**
+ * Stands in after dark. Says when the hint will next mean something,
+ * rather than leaving a blank that reads as a fault.
+ */
+const asleepSx: SxProps<Theme> = {
+  px: 1.5,
+  py: 1,
+  fontSize: "0.8rem",
+  textAlign: "center",
+  opacity: 0.75,
 };

--- a/src/components/route-eta/SunSideMark.tsx
+++ b/src/components/route-eta/SunSideMark.tsx
@@ -1,50 +1,23 @@
 import { Box, useTheme, type SxProps, type Theme } from "@mui/material";
 
-/**
- * Below which the sun is too close to straight ahead, straight behind,
- * or straight overhead for either side of the bus to be the better one
- * to sit on.
- */
+// Below this the sun is too near head-on or overhead to call a side.
 export const SUN_SIDE_THRESHOLD = 0.15;
-/** Where the sun stops getting any more sideways-on, for scaling. */
 const SUN_SIDE_FULL = 0.6;
 
-/**
- * The side taking the sun. Deep orange rather than a soft amber: the
- * app's own light theme is yellow, and an amber stroke on it says
- * nothing.
- */
+// Deep orange, not amber: the light theme is itself yellow.
 const sunlitColour = (strength: number): string =>
   `rgba(230, 81, 0, ${(0.4 + 0.6 * strength).toFixed(2)})`;
 
-/**
- * The side in shade — the one to sit on. Navy on a white row, steel on
- * a black one: a single colour dark enough to read against the light
- * theme is all but invisible against the dark one, which would leave
- * half the strokes unseen.
- */
+// Two shades: one dark enough for the light theme is invisible on the dark one.
 const shadedColour = (strength: number, dark: boolean): string =>
   dark
     ? `rgba(96, 155, 214, ${(0.4 + 0.6 * strength).toFixed(2)})`
     : `rgba(21, 58, 95, ${(0.35 + 0.55 * strength).toFixed(2)})`;
 
-/**
- * One stroke down the row's right edge, standing for the right-hand
- * side of the bus: orange if the sun falls on it, slate if that is the
- * shaded side. Nothing to read, and it does not touch the left edge —
- * that is already spoken for by the selected-stop rail.
- *
- * Nothing is drawn where the sun is too near head-on to call a side.
- * That is deliberate: a mark on every row would imply a confidence the
- * arithmetic does not have.
- */
 const SunSideMark = ({
   value,
 }: {
-  /**
-   * Which side of the bus the sun falls on over the leg leaving this
-   * stop: −1 hard left … +1 hard right. Undefined after dark.
-   */
+  /** −1 hard left … +1 hard right; undefined after dark. */
   value?: number;
 }) => {
   const dark = useTheme().palette.mode === "dark";
@@ -64,7 +37,6 @@ const SunSideMark = ({
 
 export default SunSideMark;
 
-/** In words, for anyone who cannot see the stroke. */
 export const sunSideLabel = (value?: number): string | null => {
   if (value === undefined || Math.abs(value) < SUN_SIDE_THRESHOLD) return null;
   return value > 0 ? "陽光曬右邊" : "陽光曬左邊";

--- a/src/components/route-eta/SunSideMark.tsx
+++ b/src/components/route-eta/SunSideMark.tsx
@@ -1,4 +1,4 @@
-import { Box, type SxProps, type Theme } from "@mui/material";
+import { Box, useTheme, type SxProps, type Theme } from "@mui/material";
 
 /**
  * Below which the sun is too close to straight ahead, straight behind,
@@ -17,9 +17,16 @@ const SUN_SIDE_FULL = 0.6;
 const sunlitColour = (strength: number): string =>
   `rgba(230, 81, 0, ${(0.4 + 0.6 * strength).toFixed(2)})`;
 
-/** The side in shade — the one to sit on. */
-const shadedColour = (strength: number): string =>
-  `rgba(21, 58, 95, ${(0.35 + 0.55 * strength).toFixed(2)})`;
+/**
+ * The side in shade — the one to sit on. Navy on a white row, steel on
+ * a black one: a single colour dark enough to read against the light
+ * theme is all but invisible against the dark one, which would leave
+ * half the strokes unseen.
+ */
+const shadedColour = (strength: number, dark: boolean): string =>
+  dark
+    ? `rgba(96, 155, 214, ${(0.4 + 0.6 * strength).toFixed(2)})`
+    : `rgba(21, 58, 95, ${(0.35 + 0.55 * strength).toFixed(2)})`;
 
 /**
  * One stroke down the row's right edge, standing for the right-hand
@@ -40,6 +47,7 @@ const SunSideMark = ({
    */
   value?: number;
 }) => {
+  const dark = useTheme().palette.mode === "dark";
   if (value === undefined || Math.abs(value) < SUN_SIDE_THRESHOLD) return null;
   const strength = Math.min(1, Math.abs(value) / SUN_SIDE_FULL);
   return (
@@ -47,7 +55,7 @@ const SunSideMark = ({
       sx={strokeSx}
       style={{
         backgroundColor:
-          value > 0 ? sunlitColour(strength) : shadedColour(strength),
+          value > 0 ? sunlitColour(strength) : shadedColour(strength, dark),
       }}
       aria-hidden="true"
     />

--- a/src/components/route-eta/SunSideMark.tsx
+++ b/src/components/route-eta/SunSideMark.tsx
@@ -1,0 +1,72 @@
+import { Box, type SxProps, type Theme } from "@mui/material";
+
+/**
+ * Below which the sun is too close to straight ahead, straight behind,
+ * or straight overhead for either side of the bus to be the better one
+ * to sit on.
+ */
+export const SUN_SIDE_THRESHOLD = 0.15;
+/** Where the sun stops getting any more sideways-on, for scaling. */
+const SUN_SIDE_FULL = 0.6;
+
+/**
+ * The side taking the sun. Deep orange rather than a soft amber: the
+ * app's own light theme is yellow, and an amber stroke on it says
+ * nothing.
+ */
+const sunlitColour = (strength: number): string =>
+  `rgba(230, 81, 0, ${(0.4 + 0.6 * strength).toFixed(2)})`;
+
+/** The side in shade — the one to sit on. */
+const shadedColour = (strength: number): string =>
+  `rgba(21, 58, 95, ${(0.35 + 0.55 * strength).toFixed(2)})`;
+
+/**
+ * One stroke down the row's right edge, standing for the right-hand
+ * side of the bus: orange if the sun falls on it, slate if that is the
+ * shaded side. Nothing to read, and it does not touch the left edge —
+ * that is already spoken for by the selected-stop rail.
+ *
+ * Nothing is drawn where the sun is too near head-on to call a side.
+ * That is deliberate: a mark on every row would imply a confidence the
+ * arithmetic does not have.
+ */
+const SunSideMark = ({
+  value,
+}: {
+  /**
+   * Which side of the bus the sun falls on over the leg leaving this
+   * stop: −1 hard left … +1 hard right. Undefined after dark.
+   */
+  value?: number;
+}) => {
+  if (value === undefined || Math.abs(value) < SUN_SIDE_THRESHOLD) return null;
+  const strength = Math.min(1, Math.abs(value) / SUN_SIDE_FULL);
+  return (
+    <Box
+      sx={strokeSx}
+      style={{
+        backgroundColor:
+          value > 0 ? sunlitColour(strength) : shadedColour(strength),
+      }}
+      aria-hidden="true"
+    />
+  );
+};
+
+export default SunSideMark;
+
+/** In words, for anyone who cannot see the stroke. */
+export const sunSideLabel = (value?: number): string | null => {
+  if (value === undefined || Math.abs(value) < SUN_SIDE_THRESHOLD) return null;
+  return value > 0 ? "陽光曬右邊" : "陽光曬左邊";
+};
+
+const strokeSx: SxProps<Theme> = {
+  position: "absolute",
+  right: 0,
+  top: 0,
+  bottom: 0,
+  width: "6px",
+  pointerEvents: "none",
+};

--- a/src/components/settings/OptionsList.tsx
+++ b/src/components/settings/OptionsList.tsx
@@ -20,6 +20,7 @@ import {
   DarkMode as DarkModeIcon,
   SettingsBrightness as SettingsBrightnessIcon,
   WbSunny as WbSunnyIcon,
+  EventSeat as EventSeatIcon,
   AllInclusive as AllInclusiveIcon,
   FilterAlt as FilterAltIcon,
   Vibration as VibrationIcon,
@@ -67,6 +68,8 @@ const OptionsList = ({ goToManage }: OptionsListProps) => {
     updateRefreshInterval,
     annotateScheduled,
     toggleAnnotateScheduled,
+    sunSideHint,
+    toggleSunSideHint,
     isRecentSearchShown,
     toggleIsRecentSearchShown,
   } = useContext(AppContext);
@@ -101,6 +104,22 @@ const OptionsList = ({ goToManage }: OptionsListProps) => {
         <ListItemText
           primary={t("路線篩選")}
           secondary={t(isRouteFilter ? "只顯示現時路線" : "顯示所有路線")}
+        />
+      </ListItemButton>
+      <ListItemButton
+        onClick={() => {
+          vibrate(vibrateDuration);
+          toggleSunSideHint();
+        }}
+      >
+        <ListItemAvatar>
+          <Avatar>
+            <EventSeatIcon />
+          </Avatar>
+        </ListItemAvatar>
+        <ListItemText
+          primary={t("防曬座位提示")}
+          secondary={t(sunSideHint ? "開啟" : "關閉")}
         />
       </ListItemButton>
       <ListItemButton

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -90,6 +90,10 @@ export interface AppState {
    */
   annotateScheduled: boolean;
   /**
+   * Mark which side of the bus the sun falls on, along the stop list
+   */
+  sunSideHint: boolean;
+  /**
    * Show recently searched
    */
   isRecentSearchShown: boolean;
@@ -136,6 +140,7 @@ interface AppContextValue extends AppState {
   toggleAnalytics: () => void; // not
   updateRefreshInterval: (interval: number) => void;
   toggleAnnotateScheduled: () => void;
+  toggleSunSideHint: () => void;
   toggleIsRecentSearchShown: () => void;
   changeLanguage: (lang: Language) => void;
   setFontSize: (fontSize: number) => void;
@@ -264,6 +269,7 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
       annotateScheduled: JSON.parse(
         localStorage.getItem("annotateScheduled") ?? "false"
       ),
+      sunSideHint: JSON.parse(localStorage.getItem("sunSideHint") ?? "false"),
       fontSize: JSON.parse(localStorage.getItem("fontSize") ?? "14"),
       searchRange: JSON.parse(
         localStorage.getItem("searchRange") ?? `${DEFAULT_SEARCH_RANGE}`
@@ -555,6 +561,14 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
     );
   }, []);
 
+  const toggleSunSideHint = useCallback(() => {
+    setStateRaw(
+      produce((state: State) => {
+        state.sunSideHint = !state.sunSideHint;
+      })
+    );
+  }, []);
+
   const toggleVibrateDuration = useCallback(() => {
     setStateRaw(
       produce((state: State) => {
@@ -816,6 +830,10 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
   }, [state.annotateScheduled]);
 
   useEffect(() => {
+    localStorage.setItem("sunSideHint", JSON.stringify(state.sunSideHint));
+  }, [state.sunSideHint]);
+
+  useEffect(() => {
     localStorage.setItem(
       "vibrateDuration",
       JSON.stringify(state.vibrateDuration)
@@ -860,6 +878,7 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
       toggleAnalytics,
       updateRefreshInterval,
       toggleAnnotateScheduled,
+      toggleSunSideHint,
       toggleIsRecentSearchShown,
       changeLanguage,
       setFontSize,
@@ -893,6 +912,7 @@ export const AppContextProvider = ({ children }: AppContextProviderProps) => {
       toggleAnalytics,
       updateRefreshInterval,
       toggleAnnotateScheduled,
+      toggleSunSideHint,
       toggleIsRecentSearchShown,
       changeLanguage,
       setFontSize,

--- a/src/hooks/useSunExposure.tsx
+++ b/src/hooks/useSunExposure.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useMemo, useState } from "react";
+import type { Location as GeoLocation } from "hk-bus-eta";
+import {
+  getNextSunrise,
+  getRouteSunExposure,
+  getSunPosition,
+  type RouteSunExposure,
+} from "../sun";
+
+/** How often the sun's position is re-evaluated. */
+const REFRESH_MS = 5 * 60 * 1000;
+
+/** Ticks every few minutes so the sun is allowed to move. */
+const useSunClock = (enabled: boolean): number => {
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    if (!enabled) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), REFRESH_MS);
+    return () => clearInterval(id);
+  }, [enabled]);
+  return now;
+};
+
+/**
+ * When the sun next rises, or `null` while it is already up. Used to
+ * tell a rider when the display will have something to say.
+ */
+export const useNextSunrise = (
+  location: GeoLocation | undefined,
+  enabled: boolean
+): Date | null => {
+  const now = useSunClock(enabled && location !== undefined);
+  return useMemo(() => {
+    if (!enabled || !location) return null;
+    const at = new Date(now);
+    if (getSunPosition(at, location).altitude > 0) return null;
+    return getNextSunrise(location, at);
+  }, [enabled, location, now]);
+};
+
+/**
+ * Where the sun currently falls along a route, refreshed every few
+ * minutes. `null` while the sun is below the horizon, or whenever
+ * `enabled` is false — switched off it starts no timer and does no
+ * arithmetic, so a rider who never turns it on pays nothing for it.
+ */
+export const useSunExposure = (
+  locations: GeoLocation[],
+  enabled = true
+): RouteSunExposure | null => {
+  const now = useSunClock(enabled);
+  return useMemo(
+    () => (enabled ? getRouteSunExposure(locations, new Date(now)) : null),
+    [enabled, locations, now]
+  );
+};
+
+export default useSunExposure;

--- a/src/hooks/useSunExposure.tsx
+++ b/src/hooks/useSunExposure.tsx
@@ -7,10 +7,8 @@ import {
   type RouteSunExposure,
 } from "../sun";
 
-/** How often the sun's position is re-evaluated. */
 const REFRESH_MS = 5 * 60 * 1000;
 
-/** Ticks every few minutes so the sun is allowed to move. */
 const useSunClock = (enabled: boolean): number => {
   const [now, setNow] = useState<number>(() => Date.now());
   useEffect(() => {
@@ -22,10 +20,7 @@ const useSunClock = (enabled: boolean): number => {
   return now;
 };
 
-/**
- * When the sun next rises, or `null` while it is already up. Used to
- * tell a rider when the display will have something to say.
- */
+/** When the sun next rises, or `null` while it is already up. */
 export const useNextSunrise = (
   location: GeoLocation | undefined,
   enabled: boolean
@@ -39,12 +34,7 @@ export const useNextSunrise = (
   }, [enabled, location, now]);
 };
 
-/**
- * Where the sun currently falls along a route, refreshed every few
- * minutes. `null` while the sun is below the horizon, or whenever
- * `enabled` is false — switched off it starts no timer and does no
- * arithmetic, so a rider who never turns it on pays nothing for it.
- */
+// Disabled starts no timer and does no arithmetic, so it costs nothing when off.
 export const useSunExposure = (
   locations: GeoLocation[],
   enabled = true

--- a/src/i18n/translation.js
+++ b/src/i18n/translation.js
@@ -213,6 +213,11 @@ const resources = {
       "支援 WearOS 及 WatchOS 平台": "Support WearOS & WatchOS",
       地圖資源: "Map Resources",
       同感心: "Empathy",
+      防曬座位提示: "Sun-side seat hint",
+      太陽已下山: "The sun has set",
+      日出: "Sunrise",
+      陽光曬左邊: "Sun on the left side",
+      陽光曬右邊: "Sun on the right side",
     },
   },
   zh: {

--- a/src/pages/DataImportPage.tsx
+++ b/src/pages/DataImportPage.tsx
@@ -132,6 +132,7 @@ const DataImport = () => {
       analytics: obj.analytics ?? true,
       refreshInterval: obj.refreshInterval ?? 30,
       annotateScheduled: obj.annotateScheduled ?? true,
+      sunSideHint: obj.sunSideHint ?? false,
       isRecentSearchShown: obj.isRecentSearchShown ?? true,
       fontSize: obj.fontSize ?? 16,
       searchRange: obj.searchRange ?? DEFAULT_SEARCH_RANGE,

--- a/src/sun.ts
+++ b/src/sun.ts
@@ -1,0 +1,183 @@
+import type { Location as GeoLocation } from "hk-bus-eta";
+
+/**
+ * Solar position, and from it which side of a bus the sun falls on.
+ *
+ * The astronomy is the standard low-precision solar ephemeris (mean
+ * anomaly → equation of the centre → ecliptic longitude → equatorial
+ * coordinates → horizontal coordinates), as set out in
+ * https://aa.quae.nl/en/reken/zonpositie.html. Accurate to roughly a
+ * tenth of a degree for the next century, which is far finer than
+ * "left or right of the bus" needs.
+ */
+
+const RAD = Math.PI / 180;
+const DAY_MS = 1000 * 60 * 60 * 24;
+/** Julian day number of the Unix epoch, and of J2000.0. */
+const J1970 = 2440588;
+const J2000 = 2451545;
+/** Mean obliquity of the ecliptic. */
+const OBLIQUITY = 23.4397 * RAD;
+/** Longitude of the Earth's perihelion. */
+const PERIHELION = 102.9372 * RAD;
+
+/** Days since J2000.0. */
+const toDays = (date: Date) => date.valueOf() / DAY_MS - 0.5 + J1970 - J2000;
+
+export interface SunPosition {
+  /** Bearing of the sun, degrees clockwise from true north. */
+  azimuth: number;
+  /** Height of the sun above the horizon, in degrees. */
+  altitude: number;
+}
+
+export const getSunPosition = (
+  date: Date,
+  { lat, lng }: GeoLocation
+): SunPosition => {
+  const d = toDays(date);
+
+  // Sun in ecliptic coordinates. Its ecliptic latitude is ~0, which
+  // is why the declination below drops the usual latitude terms.
+  const meanAnomaly = (357.5291 + 0.98560028 * d) * RAD;
+  const centre =
+    (1.9148 * Math.sin(meanAnomaly) +
+      0.02 * Math.sin(2 * meanAnomaly) +
+      0.0003 * Math.sin(3 * meanAnomaly)) *
+    RAD;
+  const eclipticLng = meanAnomaly + centre + PERIHELION + Math.PI;
+
+  // …then equatorial…
+  const declination = Math.asin(Math.sin(OBLIQUITY) * Math.sin(eclipticLng));
+  const rightAscension = Math.atan2(
+    Math.sin(eclipticLng) * Math.cos(OBLIQUITY),
+    Math.cos(eclipticLng)
+  );
+
+  // …then horizontal, for the observer.
+  const hourAngle =
+    (280.16 + 360.9856235 * d) * RAD + lng * RAD - rightAscension;
+  const phi = lat * RAD;
+  const altitude = Math.asin(
+    Math.sin(phi) * Math.sin(declination) +
+      Math.cos(phi) * Math.cos(declination) * Math.cos(hourAngle)
+  );
+  // atan2 form yields the azimuth measured from south, westward.
+  const azimuthFromSouth = Math.atan2(
+    Math.sin(hourAngle),
+    Math.cos(hourAngle) * Math.sin(phi) - Math.tan(declination) * Math.cos(phi)
+  );
+
+  return {
+    azimuth: (azimuthFromSouth / RAD + 180 + 360) % 360,
+    altitude: altitude / RAD,
+  };
+};
+
+/** Initial great-circle bearing from `a` to `b`, degrees from north. */
+export const getBearing = (a: GeoLocation, b: GeoLocation): number => {
+  const phi1 = a.lat * RAD;
+  const phi2 = b.lat * RAD;
+  const dLng = (b.lng - a.lng) * RAD;
+  const y = Math.sin(dLng) * Math.cos(phi2);
+  const x =
+    Math.cos(phi1) * Math.sin(phi2) -
+    Math.sin(phi1) * Math.cos(phi2) * Math.cos(dLng);
+  return (Math.atan2(y, x) / RAD + 360) % 360;
+};
+
+/**
+ * When the sun next clears the horizon at `location`, or `null` if it
+ * somehow does not within a day — which cannot happen at Hong Kong's
+ * latitude, but can inside the polar circles.
+ *
+ * Found by bisection on the altitude rather than by the closed-form
+ * sunrise equation: it is a dozen calls to `getSunPosition`, runs
+ * once when the sun is down, and cannot disagree with the altitude
+ * the rest of the feature is drawing from.
+ */
+export const getNextSunrise = (
+  location: GeoLocation,
+  from: Date = new Date()
+): Date | null => {
+  const MINUTE = 60 * 1000;
+  const altitudeAt = (t: number) =>
+    getSunPosition(new Date(t), location).altitude;
+
+  // Step forward in coarse jumps to bracket the crossing…
+  let lo = from.valueOf();
+  if (altitudeAt(lo) > 0) return from;
+  let hi = lo;
+  for (let step = 0; step < 24 * 4; ++step) {
+    hi = lo + 15 * MINUTE;
+    if (altitudeAt(hi) > 0) {
+      // …then bisect it to the nearest minute.
+      while (hi - lo > MINUTE) {
+        const mid = lo + (hi - lo) / 2;
+        if (altitudeAt(mid) > 0) hi = mid;
+        else lo = mid;
+      }
+      return new Date(hi);
+    }
+    lo = hi;
+  }
+  return null;
+};
+
+export interface RouteSunExposure {
+  /** Bearing of the sun, degrees clockwise from true north. */
+  azimuth: number;
+  /** Height of the sun above the horizon, in degrees. */
+  altitude: number;
+  /**
+   * One entry per stop, describing the leg that *starts* at that stop:
+   * −1 means the sun is square on the left of the bus, +1 square on
+   * the right, 0 straight ahead, straight behind, or directly
+   * overhead.
+   *
+   * The last stop carries the leg that *arrives* instead, having no
+   * onward one — which is also what a rider wants there, and what
+   * circular routes need, since their stop lists run the loop right
+   * back round to the starting stop.
+   */
+  sides: number[];
+}
+
+/**
+ * Where the sun falls along a route at a given moment, or `null` if
+ * the sun is below the horizon or the route has no usable geometry.
+ *
+ * The magnitude folds in the sun's altitude: a sun that is nearly
+ * overhead lights both sides of the bus about equally, so it scores
+ * near zero however the road runs.
+ */
+export const getRouteSunExposure = (
+  locations: GeoLocation[],
+  date: Date = new Date()
+): RouteSunExposure | null => {
+  if (locations.length < 2) return null;
+  const { azimuth, altitude } = getSunPosition(date, locations[0]);
+  if (altitude <= 0) return null;
+
+  const glare = Math.cos(altitude * RAD);
+  // Walked backwards so that a stop repeated at the same coordinates —
+  // which has no heading of its own — takes the heading of the next
+  // leg that does move. Going forwards would hand it the leg it
+  // arrived on, and describe the bus's last turn instead of its next.
+  const sides = locations.map(() => 0);
+  let ahead = 0;
+  for (let i = locations.length - 2; i >= 0; --i) {
+    if (
+      locations[i].lat !== locations[i + 1].lat ||
+      locations[i].lng !== locations[i + 1].lng
+    ) {
+      const heading = getBearing(locations[i], locations[i + 1]);
+      ahead = Math.sin((azimuth - heading) * RAD) * glare;
+    }
+    sides[i] = ahead;
+  }
+  // The final stop has no onward leg, so it keeps the arriving one.
+  sides[locations.length - 1] = sides[locations.length - 2];
+
+  return { azimuth, altitude, sides };
+};

--- a/src/sun.ts
+++ b/src/sun.ts
@@ -1,33 +1,19 @@
 import type { Location as GeoLocation } from "hk-bus-eta";
 
-/**
- * Solar position, and from it which side of a bus the sun falls on.
- *
- * The astronomy is the standard low-precision solar ephemeris (mean
- * anomaly → equation of the centre → ecliptic longitude → equatorial
- * coordinates → horizontal coordinates), as set out in
- * https://aa.quae.nl/en/reken/zonpositie.html. Accurate to roughly a
- * tenth of a degree for the next century, which is far finer than
- * "left or right of the bus" needs.
- */
+// Low-precision solar ephemeris, per https://aa.quae.nl/en/reken/zonpositie.html.
 
 const RAD = Math.PI / 180;
 const DAY_MS = 1000 * 60 * 60 * 24;
-/** Julian day number of the Unix epoch, and of J2000.0. */
 const J1970 = 2440588;
 const J2000 = 2451545;
-/** Mean obliquity of the ecliptic. */
 const OBLIQUITY = 23.4397 * RAD;
-/** Longitude of the Earth's perihelion. */
 const PERIHELION = 102.9372 * RAD;
 
-/** Days since J2000.0. */
 const toDays = (date: Date) => date.valueOf() / DAY_MS - 0.5 + J1970 - J2000;
 
+/** Sun bearing, degrees clockwise from true north; height above the horizon. */
 export interface SunPosition {
-  /** Bearing of the sun, degrees clockwise from true north. */
   azimuth: number;
-  /** Height of the sun above the horizon, in degrees. */
   altitude: number;
 }
 
@@ -37,8 +23,6 @@ export const getSunPosition = (
 ): SunPosition => {
   const d = toDays(date);
 
-  // Sun in ecliptic coordinates. Its ecliptic latitude is ~0, which
-  // is why the declination below drops the usual latitude terms.
   const meanAnomaly = (357.5291 + 0.98560028 * d) * RAD;
   const centre =
     (1.9148 * Math.sin(meanAnomaly) +
@@ -47,14 +31,12 @@ export const getSunPosition = (
     RAD;
   const eclipticLng = meanAnomaly + centre + PERIHELION + Math.PI;
 
-  // …then equatorial…
   const declination = Math.asin(Math.sin(OBLIQUITY) * Math.sin(eclipticLng));
   const rightAscension = Math.atan2(
     Math.sin(eclipticLng) * Math.cos(OBLIQUITY),
     Math.cos(eclipticLng)
   );
 
-  // …then horizontal, for the observer.
   const hourAngle =
     (280.16 + 360.9856235 * d) * RAD + lng * RAD - rightAscension;
   const phi = lat * RAD;
@@ -62,7 +44,6 @@ export const getSunPosition = (
     Math.sin(phi) * Math.sin(declination) +
       Math.cos(phi) * Math.cos(declination) * Math.cos(hourAngle)
   );
-  // atan2 form yields the azimuth measured from south, westward.
   const azimuthFromSouth = Math.atan2(
     Math.sin(hourAngle),
     Math.cos(hourAngle) * Math.sin(phi) - Math.tan(declination) * Math.cos(phi)
@@ -86,16 +67,7 @@ export const getBearing = (a: GeoLocation, b: GeoLocation): number => {
   return (Math.atan2(y, x) / RAD + 360) % 360;
 };
 
-/**
- * When the sun next clears the horizon at `location`, or `null` if it
- * somehow does not within a day — which cannot happen at Hong Kong's
- * latitude, but can inside the polar circles.
- *
- * Found by bisection on the altitude rather than by the closed-form
- * sunrise equation: it is a dozen calls to `getSunPosition`, runs
- * once when the sun is down, and cannot disagree with the altitude
- * the rest of the feature is drawing from.
- */
+/** Next sunrise at `location`, or `null` if none within a day (polar only). */
 export const getNextSunrise = (
   location: GeoLocation,
   from: Date = new Date()
@@ -104,14 +76,12 @@ export const getNextSunrise = (
   const altitudeAt = (t: number) =>
     getSunPosition(new Date(t), location).altitude;
 
-  // Step forward in coarse jumps to bracket the crossing…
   let lo = from.valueOf();
   if (altitudeAt(lo) > 0) return from;
   let hi = lo;
   for (let step = 0; step < 24 * 4; ++step) {
     hi = lo + 15 * MINUTE;
     if (altitudeAt(hi) > 0) {
-      // …then bisect it to the nearest minute.
       while (hi - lo > MINUTE) {
         const mid = lo + (hi - lo) / 2;
         if (altitudeAt(mid) > 0) hi = mid;
@@ -124,33 +94,12 @@ export const getNextSunrise = (
   return null;
 };
 
-export interface RouteSunExposure {
-  /** Bearing of the sun, degrees clockwise from true north. */
-  azimuth: number;
-  /** Height of the sun above the horizon, in degrees. */
-  altitude: number;
-  /**
-   * One entry per stop, describing the leg that *starts* at that stop:
-   * −1 means the sun is square on the left of the bus, +1 square on
-   * the right, 0 straight ahead, straight behind, or directly
-   * overhead.
-   *
-   * The last stop carries the leg that *arrives* instead, having no
-   * onward one — which is also what a rider wants there, and what
-   * circular routes need, since their stop lists run the loop right
-   * back round to the starting stop.
-   */
+export interface RouteSunExposure extends SunPosition {
+  // Per stop, for the leg leaving it: −1 sun square left, +1 square right.
+  // The last stop keeps its arriving leg.
   sides: number[];
 }
 
-/**
- * Where the sun falls along a route at a given moment, or `null` if
- * the sun is below the horizon or the route has no usable geometry.
- *
- * The magnitude folds in the sun's altitude: a sun that is nearly
- * overhead lights both sides of the bus about equally, so it scores
- * near zero however the road runs.
- */
 export const getRouteSunExposure = (
   locations: GeoLocation[],
   date: Date = new Date()
@@ -159,11 +108,10 @@ export const getRouteSunExposure = (
   const { azimuth, altitude } = getSunPosition(date, locations[0]);
   if (altitude <= 0) return null;
 
+  // A sun near overhead lights both sides equally, so it scores near zero.
   const glare = Math.cos(altitude * RAD);
-  // Walked backwards so that a stop repeated at the same coordinates —
-  // which has no heading of its own — takes the heading of the next
-  // leg that does move. Going forwards would hand it the leg it
-  // arrived on, and describe the bus's last turn instead of its next.
+  // Backwards, so a stop repeated at the same coordinates takes the heading of
+  // the next leg that moves rather than the one it arrived on.
   const sides = locations.map(() => 0);
   let ahead = 0;
   for (let i = locations.length - 2; i >= 0; --i) {
@@ -176,7 +124,6 @@ export const getRouteSunExposure = (
     }
     sides[i] = ahead;
   }
-  // The final stop has no onward leg, so it keeps the arriving one.
   sides[locations.length - 1] = sides[locations.length - 2];
 
   return { azimuth, altitude, sides };


### PR DESCRIPTION
Two ways to draw the same thing. Merge this one or the sibling PR — not both.

Addresses #304, replaces #308 (four presentations behind a setting; thread asked for one).

Off by default via a switch under 個性化設定; while off, no timer, no solar arithmetic, no per-stop work.

On, each stop row draws a coloured stroke down its right edge: orange if the sun falls on the right side of the bus, blue if shaded.

![on](https://raw.githubusercontent.com/evnchn/hk-independent-bus-eta/pr-assets-sun-choice/docs/sun-choice/02-bar.png)

The sibling PR draws a sun/seat icon pair instead. Verified on 74X, both languages, light/dark, on/off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional sun-side seat hints to route stop information, indicating which side may receive more sunlight.
  - Added a next-sunrise banner when applicable.
  - Added a setting to enable or disable sun-side hints, with the preference preserved between sessions.
  - Added localized labels for sunrise, sunset, and sun-side guidance.
  - Imported sun-side hint preferences from saved app data.
- **Accessibility**
  - Sun-side indicators include translated, screen-reader-friendly labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->