### PR TITLE
Fix stack overflow on routes with very long polylines

### DIFF
--- a/src/routeAlignment.ts
+++ b/src/routeAlignment.ts
@@ -194,7 +194,7 @@ export const flattenRouteGeoJson = (
       }
       if (isSameLocation(tail, part[0])) part = part.slice(1);
     }
-    points.push(...part);
+    part.forEach((point) => points.push(point));
   });
 
   return points;


### PR DESCRIPTION
points.push(...part) passes every point as a separate argument; route 15/X15 have a 191k-point segment, over V8's limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated route data processing without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->