### PR TITLE
Serve the cached route DB while a slow refresh downloads

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -117,7 +117,6 @@ export const fetchDbFunc = async (
       }
     }
     const updateTime = Date.now() + "";
-    localStorage.setItem("updateTime", updateTime);
     return new Promise((resolve_1) => {
       let servedCache = false;
       const timerId = setTimeout(async () => {
@@ -148,6 +147,7 @@ export const fetchDbFunc = async (
         }))
         .then((ret) => {
           if (servedCache) return;
+          localStorage.setItem("updateTime", updateTime);
           localStorage.setItem("schemaVersion", _schemaVersion);
           localStorage.setItem("versionMd5", _md5);
           clearTimeout(timerId);

--- a/src/db.ts
+++ b/src/db.ts
@@ -119,10 +119,12 @@ export const fetchDbFunc = async (
     const updateTime = Date.now() + "";
     localStorage.setItem("updateTime", updateTime);
     return new Promise((resolve_1) => {
-      const timerId = setTimeout(() => {
+      let servedCache = false;
+      const timerId = setTimeout(async () => {
         if (!forceRenew) {
-          const _cachedDb = loadStoredDb();
+          const _cachedDb = await loadStoredDb().catch(() => null);
           if (isEtaDb(_cachedDb)) {
+            servedCache = true;
             resolve_1(_cachedDb);
           }
         }
@@ -145,6 +147,7 @@ export const fetchDbFunc = async (
           updateTime: parseInt(updateTime),
         }))
         .then((ret) => {
+          if (servedCache) return;
           localStorage.setItem("schemaVersion", _schemaVersion);
           localStorage.setItem("versionMd5", _md5);
           clearTimeout(timerId);


### PR DESCRIPTION
From the community group — records vanishing, and the standard remedy:

> 「App入面嘅紀錄突然全部冇晒 收藏車站、路線之類」 — [77645](https://t.me/c/1160443134/77645)
> *Everything saved in the app suddenly vanished — saved stops, routes and so on.*

> 「設定，更新路線資料庫」 — [77646](https://t.me/c/1160443134/77646)
> *Settings → update route database.*

> 「呀，返嚟嚕🤣🙏🏻」 — [77647](https://t.me/c/1160443134/77647)
> *Ah, they're back.*

and separately, on ETA rather than the DB, the same underlying ask:

> 「如果網絡連接唔太好嘅情況下eta撈出嚟會較耐，建議在網絡唔好嘅情況下都能夠撈到eta Thx」 — [77775](https://t.me/c/1160443134/77775)
> *When the connection is poor it takes longer to fetch; please make it still work on a poor connection.*

That refresh already has a 1-second fallback meant to show the cached route DB while the ~8 MB download runs. It has never fired — `loadStoredDb()` returns a Promise and was never awaited, so `isEtaDb()` tested a Promise.

```mermaid
sequenceDiagram
    participant App
    participant T as 1 s timer
    participant N as Network
    N-)N: 8 MB refresh in flight
    T->>T: isEtaDb(loadStoredDb())
    rect rgba(220, 80, 80, 0.18)
        Note over App,N: today — un-awaited Promise, so always false
        N->>App: fresh DB only when the download lands, writes new md5
    end
    rect rgba(60, 180, 100, 0.18)
        Note over App,N: this branch — awaited, so true
        T->>App: cached DB at 1 s, servedCache = true
        N->>N: servedCache, so skip the version writes
    end
```

`servedCache` is why this is not a bare `await` — see the middle row.

| variant | resolved | served | `versionMd5` |
|---|---:|---|---|
| master | 6025 ms | fresh | new |
| bare `await` | 1053 ms | cached | **new** |
| this branch | 1080 ms | cached | old |

Measured with a 6 s delay and a cached DB seeded under the old md5. At 100 ms delay master and this branch both resolve fresh in ~127 ms.

`updateTime` is committed with that same metadata rather than before the download, so a cache-served session still re-checks the hash on the next launch instead of sitting on the stale copy until the seven-day mark.

Conflicts textually with #296 — happy to rebase on whichever you take first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data freshness and renewal timing when loading database results.
  * Cached fallback responses no longer incorrectly advance the renewal timestamp.
  * Renewal timing is now updated only when fresh database data is successfully selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->