### PR TITLE
Sunstrip follow zoom

### DIFF
--- a/src/components/map/maplibre/RouteMap.tsx
+++ b/src/components/map/maplibre/RouteMap.tsx
@@ -6,7 +6,14 @@ import {
   useRef,
   useState,
 } from "react";
-import { Marker, Source, Layer } from "react-map-gl/maplibre";
+import {
+  Marker,
+  Source,
+  Layer,
+  type MapEvent,
+  type ViewStateChangeEvent,
+} from "react-map-gl/maplibre";
+import type maplibregl from "maplibre-gl";
 import type { FeatureCollection } from "geojson";
 import { Box, type SxProps, type Theme } from "@mui/material";
 import type { Company, StopListEntry } from "hk-bus-eta";
@@ -97,6 +104,31 @@ const RouteMap = ({
     type: "setView" | "flyTo";
     center: GeoLocation;
   } | null>(null);
+
+  // Visible map bounds, so SunStrip can show only the sun exposure for the
+  // portion of the route actually on screen instead of the whole remaining
+  // journey. Updated once per gesture (moveend), not per frame, since each
+  // update triggers a solar-position recompute.
+  const [mapBounds, setMapBounds] = useState<
+    [GeoLocation, GeoLocation] | null
+  >(null);
+  const applyBoundsFrom = useCallback((target: maplibregl.Map) => {
+    const b = target.getBounds();
+    const sw = b.getSouthWest();
+    const ne = b.getNorthEast();
+    setMapBounds([
+      { lat: sw.lat, lng: sw.lng },
+      { lat: ne.lat, lng: ne.lng },
+    ]);
+  }, []);
+  const handleMoveEnd = useCallback(
+    (e: ViewStateChangeEvent) => applyBoundsFrom(e.target),
+    [applyBoundsFrom]
+  );
+  const handleLoad = useCallback(
+    (e: MapEvent) => applyBoundsFrom(e.target),
+    [applyBoundsFrom]
+  );
 
   // Compute next centre whenever props change.
   useEffect(() => {
@@ -191,6 +223,7 @@ const RouteMap = ({
         side="left"
         stops={stops}
         fromStopIdx={stopIdx}
+        mapBounds={mapBounds}
       />
       <BaseMap
         initialViewState={{
@@ -205,6 +238,8 @@ const RouteMap = ({
         // `cooperativeGestures` instead.
         onDragStart={handleDragStartOrEnd}
         onDragEnd={handleDragStartOrEnd}
+        onLoad={handleLoad}
+        onMoveEnd={handleMoveEnd}
         style={{ height: "35vh", flex: 1, minWidth: 0 }}
       >
         <MapEffects pending={pendingNav} onApplied={handleNavApplied} />
@@ -294,6 +329,7 @@ const RouteMap = ({
         side="right"
         stops={stops}
         fromStopIdx={stopIdx}
+        mapBounds={mapBounds}
       />
     </Box>
   );

--- a/src/components/map/maplibre/RouteMap.tsx
+++ b/src/components/map/maplibre/RouteMap.tsx
@@ -109,9 +109,9 @@ const RouteMap = ({
   // portion of the route actually on screen instead of the whole remaining
   // journey. Updated once per gesture (moveend), not per frame, since each
   // update triggers a solar-position recompute.
-  const [mapBounds, setMapBounds] = useState<
-    [GeoLocation, GeoLocation] | null
-  >(null);
+  const [mapBounds, setMapBounds] = useState<[GeoLocation, GeoLocation] | null>(
+    null
+  );
   const applyBoundsFrom = useCallback((target: maplibregl.Map) => {
     const b = target.getBounds();
     const sw = b.getSouthWest();

--- a/src/components/map/maplibre/SunStrip.tsx
+++ b/src/components/map/maplibre/SunStrip.tsx
@@ -6,6 +6,7 @@ import {
   flattenRouteGeoJson,
   getSideExposure,
   getSolarProfile,
+  resampleAlignment,
   snapStopSequenceToAlignment,
 } from "../../../routeAlignment";
 import { GeoJsonType } from "../../../hooks/useRoutePath";
@@ -13,6 +14,10 @@ import { StopListEntry } from "hk-bus-eta";
 
 const STRIP_WIDTH_PX = 4;
 const GRADIENT_STOP_COUNT = 96;
+// Denser than GRADIENT_STOP_COUNT: just lat/lng interpolation (no solar
+// math), so this stays cheap even at high zoom where the viewport can be
+// narrower than the gap between two gradient stops.
+const BOUNDS_SAMPLE_COUNT = 400;
 const RECOMPUTE_INTERVAL_MS = 10 * 60 * 1000;
 const OPACITY_GAMMA = 0.55;
 
@@ -43,13 +48,23 @@ const stripSx: SxProps<Theme> = {
   height: "35vh",
 };
 
+type LatLng = { lat: number; lng: number };
+
 interface SunStripProps {
   routePath: GeoJsonType | null;
   side: "left" | "right";
   stops: StopListEntry[];
   fromStopIdx: number;
   journeyDurationMs?: number;
+  /** Current map viewport (south-west, north-east corners); restricts the
+   *  sampled range to what's on screen so the strip doesn't imply sun
+   *  exposure for a part of the journey the map isn't currently showing.
+   *  `null` = full journey. */
+  mapBounds?: [LatLng, LatLng] | null;
 }
+
+const isInBounds = ({ lat, lng }: LatLng, [sw, ne]: [LatLng, LatLng]) =>
+  lat >= sw.lat && lat <= ne.lat && lng >= sw.lng && lng <= ne.lng;
 
 const SunStrip = ({
   routePath,
@@ -57,6 +72,7 @@ const SunStrip = ({
   stops,
   fromStopIdx,
   journeyDurationMs = 0,
+  mapBounds = null,
 }: SunStripProps) => {
   const { t } = useTranslation();
   const isDark = useTheme().palette.mode === "dark";
@@ -84,6 +100,31 @@ const SunStrip = ({
     [stops, snappedStops]
   );
 
+  // Clip [fromMetres, toMetres] down to whatever's currently on screen, so
+  // the strip tracks the map instead of always describing the whole
+  // remaining journey. `null` bounds (map not loaded yet) keeps full range.
+  const visibleRange = useMemo((): [number, number] | null => {
+    if (!mapBounds) return [fromMetres, toMetres];
+    if (alignment.points.length < 2) return null;
+    // Sample at the same resolution as the gradient itself — checking the
+    // sparse route vertices directly can miss entirely when zoomed in
+    // tight enough that no vertex happens to land inside the viewport.
+    const samples = resampleAlignment(
+      alignment,
+      BOUNDS_SAMPLE_COUNT,
+      fromMetres,
+      toMetres
+    );
+    let visLo = Infinity;
+    let visHi = -Infinity;
+    samples.forEach(({ distanceMetres, ...point }) => {
+      if (!isInBounds(point, mapBounds)) return;
+      if (distanceMetres < visLo) visLo = distanceMetres;
+      if (distanceMetres > visHi) visHi = distanceMetres;
+    });
+    return visLo <= visHi ? [visLo, visHi] : null;
+  }, [alignment, fromMetres, toMetres, mapBounds]);
+
   useEffect(() => {
     const id = setInterval(() => setNow(new Date()), RECOMPUTE_INTERVAL_MS);
     return () => clearInterval(id);
@@ -91,19 +132,20 @@ const SunStrip = ({
 
   const gradient = useMemo(() => {
     if (alignment.points.length < 2) return null;
+    if (!visibleRange) return null;
     const samples = getSolarProfile(alignment, {
       startTime: now,
       durationMs: journeyDurationMs,
       count: GRADIENT_STOP_COUNT,
-      fromMetres,
-      toMetres,
+      fromMetres: visibleRange[0],
+      toMetres: visibleRange[1],
     });
     if (samples.every(({ ele }) => ele <= 0)) return null;
     const ramp = isDark ? DARK_RAMP : LIGHT_RAMP;
     return `linear-gradient(to bottom, ${samples
       .map((sample) => sampleRamp(ramp, getSideExposure(sample, side)))
       .join(", ")})`;
-  }, [alignment, now, journeyDurationMs, fromMetres, toMetres, isDark, side]);
+  }, [alignment, now, journeyDurationMs, visibleRange, isDark, side]);
 
   if (gradient === null) return null;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sun exposure indicators now reflect only the portion of the route currently visible on the map.
  * Indicators update after map movement and when the map first loads.
  * Sun exposure indicators are hidden when no part of the route is visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->